### PR TITLE
Fix remarks in ResourceLoader Constructors

### DIFF
--- a/microsoft.applicationmodel.resources/resourceloader_resourceloader_1221375020.md
+++ b/microsoft.applicationmodel.resources/resourceloader_resourceloader_1221375020.md
@@ -14,7 +14,7 @@ public ResourceLoader()
 Constructs a new [ResourceLoader](resourceloader.md) object for the "Resources" subtree of the currently running app's main [ResourceMap](resourcemap.md).
 
 ## -remarks
-The empty constructor typically allows access relative to a resource file's resources (resources.resjson or resources.resw).
+The empty constructor typically allows access relative to a resource file's resources.
 
 This constructor fails with an exception if the main [ResourceMap](resourcemap.md) does not have a "Resources" subtree.
 

--- a/microsoft.windows.applicationmodel.resources/resourceloader_resourceloader_1221375020.md
+++ b/microsoft.windows.applicationmodel.resources/resourceloader_resourceloader_1221375020.md
@@ -16,7 +16,7 @@ Constructs a new [ResourceLoader](resourceloader.md) object for the "Resources" 
 
 ## -remarks
 
-The empty constructor typically allows access relative to a resource file's resources (resources.resjson or resources.resw).
+The empty constructor typically allows access relative to a resource file's resources.
 
 This constructor fails with an exception if the main [ResourceMap](resourcemap.md) does not have a "Resources" subtree.
 


### PR DESCRIPTION
Fix remarks in ResourceLoader Constructors by removing a reference to some resources that cannot be loaded