### PR TITLE
Update inputscopenamevalue.md for a Policheck issue

### DIFF
--- a/microsoft.ui.xaml.input/inputscopenamevalue.md
+++ b/microsoft.ui.xaml.input/inputscopenamevalue.md
@@ -81,7 +81,7 @@ Input scope is intended for working with telephone numbers.
 
 ### -field TelephoneCountryCode:33
 
-Input scope is intended for working with a numeric telephone country code.
+Input scope is intended for working with a numeric telephone country/region code.
 
 ### -field TelephoneAreaCode:34
 


### PR DESCRIPTION
Replace "country" with "country/region" to be more geo-friendly. The updated text matches the same value in the WPF docs.

Matching change for Windows.UI.Xaml: https://github.com/MicrosoftDocs/winrt-api/pull/2300