### PR TITLE
Update debugsettings_enableframeratecounter.md

### DIFF
--- a/microsoft.ui.xaml/debugsettings_enableframeratecounter.md
+++ b/microsoft.ui.xaml/debugsettings_enableframeratecounter.md
@@ -11,6 +11,11 @@ public bool EnableFrameRateCounter { get;  set; }
 
 ## -description
 
+> [!CAUTION]
+> Use of this property is unsupported at this time and will result in an exception.
+> 
+> See https://github.com/microsoft/microsoft-ui-xaml/issues/2835
+
 Gets or sets a value that indicates whether to display frame-rate and per-frame CPU usage info. These display as an overlay of counters in the window chrome while the app runs.
 
 ## -property-value


### PR DESCRIPTION
This property has been unusable for ~3 years or longer and should be documented as unsupported or deprecated.