### PR TITLE
Update remarks for AppWindowTitleBar supported version

### DIFF
--- a/microsoft.ui.windowing/appwindow.md
+++ b/microsoft.ui.windowing/appwindow.md
@@ -16,7 +16,7 @@ Represents a system-managed container for the content of an app.
 ## -remarks
 
 > [!IMPORTANT]
-> Title bar customization APIs are currently supported on Windows 11 only. You should check [AppWindowTitleBar.IsCustomizationSupported](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported) in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
+> Title bar customization APIs are partially supported on Windows 10 since Windows App SDK 1.2 and fully supported on Windows 11. You should check [AppWindowTitleBar.IsCustomizationSupported](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported) in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
 
 ## -see-also
 

--- a/microsoft.ui.windowing/appwindow_titlebar.md
+++ b/microsoft.ui.windowing/appwindow_titlebar.md
@@ -20,7 +20,7 @@ The title bar of the app window.
 ## -remarks
 
 > [!IMPORTANT]
-> Title bar customization APIs are currently supported on Windows 11 only. You should check [AppWindowTitleBar.IsCustomizationSupported](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported) in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
+> Title bar customization APIs are partially supported on Windows 10 since Windows App SDK 1.2 and fully supported on Windows 11. You should check [AppWindowTitleBar.IsCustomizationSupported](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported) in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
 
 ## -see-also
 

--- a/microsoft.ui.windowing/appwindowtitlebar.md
+++ b/microsoft.ui.windowing/appwindowtitlebar.md
@@ -16,7 +16,7 @@ Represents the title bar of an app window.
 ## -remarks
 
 > [!IMPORTANT]
-> Title bar customization APIs are currently supported on Windows 11 only. You should check [AppWindowTitleBar.IsCustomizationSupported](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported) in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
+> Title bar customization APIs are partially supported on Windows 10 since Windows App SDK 1.2 and fully supported on Windows 11. You should check [AppWindowTitleBar.IsCustomizationSupported](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.iscustomizationsupported) in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
 
 ## -see-also
 

--- a/microsoft.ui.windowing/appwindowtitlebar_iscustomizationsupported_738191503.md
+++ b/microsoft.ui.windowing/appwindowtitlebar_iscustomizationsupported_738191503.md
@@ -21,7 +21,7 @@ Gets a value that indicates whether the title bar can be customized.
 ## -remarks
 
 > [!IMPORTANT]
-> Title bar customization APIs are currently supported on Windows 11 only. You should check `IsCustomizationSupported` in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
+> Title bar customization APIs are partially supported on Windows 10 since Windows App SDK 1.2 and fully supported on Windows 11. You should check `IsCustomizationSupported` in your code before you call these APIs to ensure your app doesn't crash on other versions of Windows. See [Title bar customization](/windows/apps/develop/title-bar?tabs=wasdk) for more info.
 
 ## -see-also
 


### PR DESCRIPTION
Since the release of Windows App SDK 1.2, title bar customization using `AppWindowTitleBar` is supported downlevel on Windows 10. The [release note page](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/stable-channel#version-12-stable) for WinAppSDK has a summary for this under "Windowing" section.

This PR is to update the MSDN doc to capture the latest changes. 