### PR TITLE
Update itextrange_cut_1740700893.md

### DIFF
--- a/microsoft.ui.text/itextrange_cut_1740700893.md
+++ b/microsoft.ui.text/itextrange_cut_1740700893.md
@@ -13,8 +13,6 @@ public void Cut()
 Moves the text of the text range to the Clipboard.
 
 ## -remarks
-> [!NOTE]
-> On Windows Phone, this method throws an exception. Programmatic access to the clipboard is not supported on Windows Phone.
 
 ## -examples
 


### PR DESCRIPTION
As Windows Phone is not supported, the proposal of removing the note in Remarks:
> [!NOTE]
> On Windows Phone