### PR TITLE
Update elementtheme.md

### DIFF
--- a/microsoft.ui.xaml/elementtheme.md
+++ b/microsoft.ui.xaml/elementtheme.md
@@ -36,7 +36,7 @@ This enumeration is used as a value by the [RequestedTheme](frameworkelement_req
 
 
 > [!NOTE]
-> On Windows, setting [RequestedTheme](application_requestedtheme.md) to Default will always result in "Dark" being the theme. On Windows Phone, using the Default value will result in a query for the system theme, as set by the user.
+> On Windows, setting [RequestedTheme](application_requestedtheme.md) to Default will always result in "Dark" being the theme.
 
 ## -examples
 


### PR DESCRIPTION
As Windows Phone is not supported, the proposal of removing the note in Remarks: [!NOTE]
...On Windows Phone, using the Default value will result in a query for the system theme, as set by the user.