### PR TITLE
Update navigationtransitioninfo.md

### DIFF
--- a/microsoft.ui.xaml.media.animation/navigationtransitioninfo.md
+++ b/microsoft.ui.xaml.media.animation/navigationtransitioninfo.md
@@ -18,8 +18,6 @@ Navigation transition animations can be any of the *TransitionInfo types. For UW
 - [DrillInNavigationTransitionInfo](drillinnavigationtransitioninfo.md)
 - [SuppressNavigationTransitionInfo](suppressnavigationtransitioninfo.md)
 
-> For Windows Phone 8.x apps, several derived types ([CommonNavigationTransitionInfo](commonnavigationtransitioninfo.md), [ContinuumNavigationTransitionInfo](continuumnavigationtransitioninfo.md), [SlideNavigationTransitionInfo](slidenavigationtransitioninfo.md)) can be used in XAML to fill the [NavigationThemeTransition.DefaultNavigationTransitionInfo](navigationthemetransition_defaultnavigationtransitioninfo.md) property.
-
 ## -examples
 ```xaml
 <Frame x:Name="myFrame">


### PR DESCRIPTION
As Windows Phone is not supported, and Phone 8.x apps are not in use I think this should be removed: "For Windows Phone 8.x apps, several derived types (CommonNavigationTransitionInfo, ContinuumNavigationTransitionInfo, SlideNavigationTransitionInfo) can be used in XAML to fill the NavigationThemeTransition.DefaultNavigationTransitionInfo property."