### PR TITLE
Update rendertargetbitmap_renderasync_318933921.md

### DIFF
--- a/microsoft.ui.xaml.media.imaging/rendertargetbitmap_renderasync_318933921.md
+++ b/microsoft.ui.xaml.media.imaging/rendertargetbitmap_renderasync_318933921.md
@@ -35,7 +35,6 @@ There are a few scenarios for XAML-composed visual content that you can't captur
 + Custom Microsoft DirectX content (your own swap chain) inside a [SwapChainBackgroundPanel](../microsoft.ui.xaml.controls/swapchainbackgroundpanel.md) or [SwapChainPanel](../microsoft.ui.xaml.controls/swapchainpanel.md) can't be captured using [RenderTargetBitmap](rendertargetbitmap.md).
 + Content that's in the tree but with its [Visibility](../microsoft.ui.xaml/uielement_visibility.md) set to **Collapsed** won't be captured.
 + Content that's not directly connected to the XAML visual tree and the content of the main window won't be captured. This includes [Popup](../microsoft.ui.xaml.controls.primitives/popup.md) content, which is considered to be like a sub-window.
-+ For Windows Phone 8.x app: the contents of a [WebView](/uwp/api/windows.ui.xaml.controls.webview) control can't be rendered into a [RenderTargetBitmap](rendertargetbitmap.md).
 + Content that can't be captured will appear as blank in the captured image, but other content in the same visual tree can still be captured and will render (the presence of content that can't be captured won't invalidate the entire capture of that XAML composition).
 + Content that's in the XAML visual tree but offscreen can be captured, so long as it's not [Visibility](../microsoft.ui.xaml/uielement_visibility.md) = **Collapsed** or in the other restricted cases.
 


### PR DESCRIPTION
As Windows Phone Apps are not in use (or supporter) proposal for removing line: "For Windows Phone 8.x app: the content..."