### PR TITLE
Update reference to app.xaml to App.xaml in Multiwindowing sample

### DIFF
--- a/microsoft.ui.xaml/window.md
+++ b/microsoft.ui.xaml/window.md
@@ -21,7 +21,7 @@ You can create more than one `Window` per thread in your apps. See [Create a new
 
 Typically, `Window` is used to set a [UIElement](uielement.md) to the [Content](window_content.md) that represents the app UI. This is usually done as part of app activation (for example in the [OnLaunched](application_onlaunched_1344752508.md) override) and allows you to change the window content throughout the lifetime of the window.
 
-Ensure you call [Activate](window_activate_1797342875.md) on any `Window` used on initial activation. If you use the default app templates from Microsoft Visual Studio, [Window.Activate](window_activate_1797342875.md) is included in the app.xaml code-behind file.
+Ensure you call [Activate](window_activate_1797342875.md) on any `Window` used on initial activation. If you use the default app templates from Microsoft Visual Studio, [Window.Activate](window_activate_1797342875.md) is included in the App.xaml code-behind file.
 
 ## -see-also
 


### PR DESCRIPTION
When creating a new project, the file is called "App.xaml", not "app.xaml". Maybe the file name should be highlighted using code tags?