### PR TITLE
Updates to custom titlebar docs post appwindow titlebar merge 

### DIFF
--- a/microsoft.ui.xaml/window_extendscontentintotitlebar.md
+++ b/microsoft.ui.xaml/window_extendscontentintotitlebar.md
@@ -23,7 +23,7 @@ Use this property in conjunction with the [SetTitleBar](window_settitlebar_14947
 
 To specify a custom title bar, you must set `ExtendsContentIntoTitleBar` to `true` to hide the default system title bar. If `ExtendsContentIntoTitleBar` is `false`, a call to `SetTitleBar` does not have any effect. Your custom title bar element is shown in the body of your app window as an ordinary UI element and does not get the title bar behaviors.
 
-If you set `ExtendsContentIntoTitleBar` to `true` but do not call `SetTitleBar`, the system title bar is restricted to the caption buttons and a small area next to the caption buttons that is reserved for title bar behaviors. It is called Fallback Titlebar. However, your custom title bar element does not get title bar behaviors, such as drag and the system menu, until [SetTitleBar](window_settitlebar_1494775390.md) is called with a valid [UIElement](uielement.md).
+If you set `ExtendsContentIntoTitleBar` to `true` but do not call `SetTitleBar`, a default custom title bar is provided. See [SetTitleBar](window_settitlebar_1494775390.md) for more details on this.
 
 ## -see-also
 

--- a/microsoft.ui.xaml/window_settitlebar_1494775390.md
+++ b/microsoft.ui.xaml/window_settitlebar_1494775390.md
@@ -25,62 +25,24 @@ Call this method to replace the system title bar with a custom title bar UI for 
 
 The rectangular area occupied by the specified element acts as the title bar for pointer purposes, even if the element is blocked by another element, or the element is transparent.
 
-If you want to place interactive elements in the title bar area, you can reduce the width of the UIElement set as title bar so that it only covers the right side of title bar region. As a result, the remaining left side will not act as the title bar, and thus, can receive pointer input. This area can host text boxes, buttons, and other interactive controls. Currently, it is not possible to have interactive elements hosted in between the drag region and caption controls region.
+If you want to place interactive elements in the title bar area, you can use [InputNonClientPointerSource](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource) apis. Refer to the [Titlebar](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/ControlPages/TitleBarPage.xaml.cs) sample in [WinUI Gallery](https://github.com/microsoft/WinUI-Gallery) for an example. 
 
 ## Extend content into title bar
 
 To specify a custom title bar, you must set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` to hide the default system title bar. If `ExtendsContentIntoTitleBar` is `false`, the call to `SetTitleBar` does not have any effect. Your custom title bar element is shown in the body of your app window as an ordinary UI element and does not get the title bar behaviors.
 
-If you set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` but do not call `SetTitleBar`, the system title bar is restricted to the caption buttons and a small area next to the caption buttons that is reserved for title bar behaviors. It is called Fallback Titlebar. However, your custom title bar element does not get title bar behaviors, such as drag and the system menu, until [SetTitleBar](window_settitlebar_1494775390.md) is called with a valid [UIElement](uielement.md).
+If you set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` but do not call `SetTitleBar` (same as calling `SetTitlebar` with a **null** argument), a default custom title bar will provided. This default title bar is direct replacement of system title bar in position, width and height, and most common use of this feature. If one wants a specialized title bar, they can call [SetTitleBar](window_settitlebar_1494775390.md) with a [`UIElement`](uielement.md) and get a title bar area on that `UIElement`'s position, width and height.
+That `UIElement` can be hosted anywhere within the contents of the app, not just the non-client area.
 
 ## Title bar element
 
-Only a single element can be specified as the title bar. If multiple elements are required, they can be specified as child elements of a single container (such as a [Grid](../microsoft.ui.xaml.controls/grid.md) or [StackPanel](../microsoft.ui.xaml.controls/stackpanel.md)). If multiple elements are specified instead of a container, the last element specified is used.
+Only a single element can be specified as the title bar. If multiple elements are required, they can be specified as child elements of a single container (such as a [Grid](../microsoft.ui.xaml.controls/grid.md) or [StackPanel](../microsoft.ui.xaml.controls/stackpanel.md)). 
 
-The custom title bar works best when it is the top-most child of the parent container of your app. Deep nesting the [UIElement](uielement.md) within the XAML tree might cause unpredictable layout behaviors. Adding right margin to the titlebar [UIElement](uielement.md) also affects its functionality and is not recommended.
-
-For example:
-
-```xaml
-<!-- NOT RECOMMENDED -->
-<Grid x:Name="RootGrid">
-    <StackPanel>
-        <StackPanel x:Name="CustomTitleBar" Margin="0,0,120,0">
-        <... more XAML ...>
-    </StackPanel>
-    <... more XAML ...>
-</Grid>
-```
+The custom title bar works best when it is not deep nested within the app. Deep nesting the [UIElement](uielement.md) within the XAML tree can cause unpredictable layout behaviors. The title bar will always be a of rectangular shape. In case of non-rectangular `UIElement`, its rectangular bounding rectangle will be used for dimensions of the title bar.
 
 ## Colors
-
-When you use a custom title bar, you can modify the colors of the caption buttons to match your app.  To do so, override the following resources (shown here with their default values):
-
-```xaml
-<StaticResource x:Key="WindowCaptionBackground" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-<StaticResource x:Key="WindowCaptionBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-<StaticResource x:Key="WindowCaptionForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
-<StaticResource x:Key="WindowCaptionForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-```
-
-This example shows how to override the default values in App.xaml.
-
-```xaml
-<Application.Resources>
-    <ResourceDictionary>
-        <ResourceDictionary.MergedDictionaries>
-            <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-            <!-- Other merged dictionaries here -->
-        </ResourceDictionary.MergedDictionaries>
-        <!-- Other app resources here -->
-        <SolidColorBrush x:Key="WindowCaptionBackground">Green</SolidColorBrush>
-        <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled">LightGreen</SolidColorBrush>
-        <SolidColorBrush x:Key="WindowCaptionForeground">Red</SolidColorBrush>
-        <SolidColorBrush x:Key="WindowCaptionForegroundDisabled">Pink</SolidColorBrush>
-    </ResourceDictionary>
-</Application.Resources>
-```
-This will paint the new colors over any content of the custom title bar, excluding the caption buttons. If you want to avoid that, you can set `WindowCaptionBackground` to `Transparent` and modify the `Background` property of the `UIElement` set as the title bar to get the desired results, without it overwriting any contents on it.
+Custom title bar uses [AppWindow title bar](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar) underneath, for its implementation. As a result, one can use AppWindowTitleBar theming apis for colors like [`ButtonBackgroundColor`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.buttonbackgroundcolor), [`ButtonForegroundColor`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.buttonforegroundcolor) etc.
+The earlier resource based theming (like `WindowCaptionBackground`) is deprecated and doesn't have any effect.
 
 ## -examples
 
@@ -119,7 +81,7 @@ public MainWindow()
     this.InitializeComponent();
 
     ExtendsContentIntoTitleBar = true;
-    SetTitleBar(AppTitleBar);
+    SetTitleBar(AppTitleBar);  // skip call to this api to get a default custom title bar
 }
 ```
 

--- a/microsoft.ui.xaml/window_settitlebar_1494775390.md
+++ b/microsoft.ui.xaml/window_settitlebar_1494775390.md
@@ -25,24 +25,24 @@ Call this method to replace the system title bar with a custom title bar UI for 
 
 The rectangular area occupied by the specified element acts as the title bar for pointer purposes, even if the element is blocked by another element, or the element is transparent.
 
-If you want to place interactive elements in the title bar area, you can use [InputNonClientPointerSource](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource) apis. Refer to the [Titlebar](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/ControlPages/TitleBarPage.xaml.cs) sample in [WinUI Gallery](https://github.com/microsoft/WinUI-Gallery) for an example. 
+If you want to place interactive elements in the title bar area, you can use [InputNonClientPointerSource](/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource) APIs. Refer to the [Titlebar](https://github.com/microsoft/WinUI-Gallery/blob/main/WinUIGallery/ControlPages/TitleBarPage.xaml.cs) page in the [WinUI Gallery](https://github.com/microsoft/WinUI-Gallery) sample for an example. 
 
 ## Extend content into title bar
 
 To specify a custom title bar, you must set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` to hide the default system title bar. If `ExtendsContentIntoTitleBar` is `false`, the call to `SetTitleBar` does not have any effect. Your custom title bar element is shown in the body of your app window as an ordinary UI element and does not get the title bar behaviors.
 
-If you set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` but do not call `SetTitleBar` (same as calling `SetTitlebar` with a **null** argument), a default custom title bar will provided. This default title bar is direct replacement of system title bar in position, width and height, and most common use of this feature. If one wants a specialized title bar, they can call [SetTitleBar](window_settitlebar_1494775390.md) with a [`UIElement`](uielement.md) and get a title bar area on that `UIElement`'s position, width and height.
-That `UIElement` can be hosted anywhere within the contents of the app, not just the non-client area.
+If you set [ExtendsContentIntoTitleBar](window_extendscontentintotitlebar.md) to `true` but do not call `SetTitleBar` (or call `SetTitlebar` with a `null` argument), a default custom title bar is provided. This default title bar is a direct replacement of the system title bar in position, width, and height. If you want a specialized title bar, you can call [SetTitleBar](window_settitlebar_1494775390.md) with a [`UIElement`](uielement.md) and get a title bar area on that `UIElement`'s position, width, and height. That `UIElement` can be hosted anywhere within the contents of the app, not just the non-client area.
 
 ## Title bar element
 
 Only a single element can be specified as the title bar. If multiple elements are required, they can be specified as child elements of a single container (such as a [Grid](../microsoft.ui.xaml.controls/grid.md) or [StackPanel](../microsoft.ui.xaml.controls/stackpanel.md)). 
 
-The custom title bar works best when it is not deep nested within the app. Deep nesting the [UIElement](uielement.md) within the XAML tree can cause unpredictable layout behaviors. The title bar will always be a of rectangular shape. In case of non-rectangular `UIElement`, its rectangular bounding rectangle will be used for dimensions of the title bar.
+The custom title bar works best when it is not deep nested within the app. Deep nesting the [UIElement](uielement.md) within the XAML tree can cause unpredictable layout behaviors. The title bar will always be a of rectangular shape. In case of a non-rectangular `UIElement`, its rectangular bounding rectangle will be used for dimensions of the title bar.
 
 ## Colors
-Custom title bar uses [AppWindow title bar](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar) underneath, for its implementation. As a result, one can use AppWindowTitleBar theming apis for colors like [`ButtonBackgroundColor`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.buttonbackgroundcolor), [`ButtonForegroundColor`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.buttonforegroundcolor) etc.
-The earlier resource based theming (like `WindowCaptionBackground`) is deprecated and doesn't have any effect.
+A custom title bar uses an [AppWindow title bar](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar) for its implementation. As a result, you can use AppWindowTitleBar theming APIs for colors like [`ButtonBackgroundColor`](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.buttonbackgroundcolor), [`ButtonForegroundColor`](/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar.buttonforegroundcolor), etc.
+
+The resource based theming used in earlier versions (like `WindowCaptionBackground`) is deprecated and doesn't have any effect.
 
 ## -examples
 


### PR DESCRIPTION
With Winappsdk 1.4, WinUI 3 custom titlebar now uses Appwindow titlebar underneath. As a result, there are a few changes which require to be documented. This PR captures all those changes and adds them to the doc.