### PR TITLE
Remove unnecessary period after the "Open the WinUI 3 Gallery app..." button

### DIFF
--- a/microsoft.ui.xaml.automation.peers/animatedvisualplayerautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/animatedvisualplayerautomationpeer.md
@@ -22,6 +22,6 @@ Exposes [AnimatedVisualPlayer](../microsoft.ui.xaml.controls/animatedvisualplaye
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.automation.peers/colorpickersliderautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/colorpickersliderautomationpeer.md
@@ -21,7 +21,7 @@ Exposes [ColorPickerSlider](../microsoft.ui.xaml.controls.primitives/colorpicker
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/colorspectrumautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/colorspectrumautomationpeer.md
@@ -21,6 +21,6 @@ Exposes [ColorSpectrum](../microsoft.ui.xaml.controls.primitives/colorspectrum.m
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.automation.peers/dropdownbuttonautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/dropdownbuttonautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [DropDownButton](../microsoft.ui.xaml.controls/dropdownbutton.md) types 
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/menubarautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/menubarautomationpeer.md
@@ -21,7 +21,7 @@ Exposes [MenuBar](menubarautomationpeer.md) types to [Microsoft UI Automation](/
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/menubaritemautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/menubaritemautomationpeer.md
@@ -23,6 +23,5 @@ Exposes [MenuBarItem](../microsoft.ui.xaml.controls/menubaritem.md) types to [Mi
 > [!div class="nextstepaction"]
 > [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
-
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/menubaritemautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/menubaritemautomationpeer.md
@@ -21,7 +21,8 @@ Exposes [MenuBarItem](../microsoft.ui.xaml.controls/menubaritem.md) types to [Mi
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
+
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/microsoft_ui_xaml_automation_peers.md
+++ b/microsoft.ui.xaml.automation.peers/microsoft_ui_xaml_automation_peers.md
@@ -27,7 +27,7 @@ WinUI controls, and other UI elements, implement UI Automation support to report
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/navigationviewitemautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/navigationviewitemautomationpeer.md
@@ -21,7 +21,7 @@ Exposes [NavigationViewItem](../microsoft.ui.xaml.controls/navigationviewitem.md
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/numberboxautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/numberboxautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [NumberBox](../microsoft.ui.xaml.controls/numberbox.md) types to [Micros
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/personpictureautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/personpictureautomationpeer.md
@@ -21,7 +21,7 @@ Exposes [PersonPicture](../microsoft.ui.xaml.controls/personpicture.md) types to
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/pipspagerautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/pipspagerautomationpeer.md
@@ -23,7 +23,7 @@ Exposes [PipsPager](../microsoft.ui.xaml.controls/pipspager.md) types to [Micros
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/progressbarautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/progressbarautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [ProgressBar](../microsoft.ui.xaml.controls/progressbar.md) types to [Mi
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/progressringautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/progressringautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [ProgressRing](../microsoft.ui.xaml.controls/progressring.md) types to [
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/radiobuttonsautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/radiobuttonsautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [RadioButtons](../microsoft.ui.xaml.controls/radiobuttons.md) types to [
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/ratingcontrolautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/ratingcontrolautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [RatingControl](../microsoft.ui.xaml.controls/ratingcontrol.md) types to
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/repeaterautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/repeaterautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [ItemsRepeater](../microsoft.ui.xaml.controls/itemsrepeater.md) types to
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/splitbuttonautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/splitbuttonautomationpeer.md
@@ -22,6 +22,6 @@ Exposes [SplitButton](../microsoft.ui.xaml.controls/splitbutton.md) types to [Mi
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.automation.peers/tabviewautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/tabviewautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [TabView](../microsoft.ui.xaml.controls/tabview.md) types to [Microsoft 
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/tabviewitemautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/tabviewitemautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [TabViewItem](../microsoft.ui.xaml.controls/tabviewitem.md) types to [Mi
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/teachingtipautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/teachingtipautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [TeachingTip](../microsoft.ui.xaml.controls/teachingtip.md) types to [Mi
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/togglesplitbuttonautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/togglesplitbuttonautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [ToggleSplitButton](../microsoft.ui.xaml.controls/togglesplitbutton.md) 
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/treeviewitemautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/treeviewitemautomationpeer.md
@@ -21,7 +21,7 @@ Exposes [TreeViewItem](../microsoft.ui.xaml.controls/treeviewitem.md) types to [
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/treeviewitemdataautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/treeviewitemdataautomationpeer.md
@@ -22,7 +22,7 @@ Exposes [TreeViewItem](../microsoft.ui.xaml.controls/treeviewitem.md) data types
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/treeviewlistautomationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/treeviewlistautomationpeer.md
@@ -21,7 +21,7 @@ Exposes [TreeViewList](../microsoft.ui.xaml.controls/treeviewlist.md) types to [
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.automation.peers/webview2automationpeer.md
+++ b/microsoft.ui.xaml.automation.peers/webview2automationpeer.md
@@ -22,7 +22,7 @@ Exposes [WebView2](../microsoft.ui.xaml.controls/webview2.md) types to [Microsof
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties).
+> [Open the WinUI 3 Gallery app and see AutomationProperties in action](winui3gallery:/item/AutomationProperties)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls.primitives/colorpickerslider.md
+++ b/microsoft.ui.xaml.controls.primitives/colorpickerslider.md
@@ -23,6 +23,6 @@ Represents a slider in a [ColorPicker](../microsoft.ui.xaml.controls/colorpicker
 > For more info, design guidance, and code examples, see [Color picker](/windows/apps/design/controls/color-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker).
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls.primitives/colorspectrum.md
+++ b/microsoft.ui.xaml.controls.primitives/colorspectrum.md
@@ -24,6 +24,6 @@ ColorSpectrum is a component of the [ColorPicker](../microsoft.ui.xaml.controls/
 > For more info, design guidance, and code examples, see [Color picker](/windows/apps/design/controls/color-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker).
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls.primitives/commandbarflyoutcommandbar.md
+++ b/microsoft.ui.xaml.controls.primitives/commandbarflyoutcommandbar.md
@@ -22,6 +22,6 @@ Represents a specialized command bar used in a CommandBarFlyout.
 > For more info, design guidance, and code examples, see [Command bar flyout](/windows/apps/design/controls/command-bar-flyout).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery:/item/CommandBarFlyout).
+> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery:/item/CommandBarFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls.primitives/repeatbutton.md
+++ b/microsoft.ui.xaml.controls.primitives/repeatbutton.md
@@ -33,7 +33,7 @@ A RepeatButton is a button that raises [Click](buttonbase_click.md) events repea
 > For more info, design guidance, and code examples, see [Buttons](/windows/apps/design/controls/buttons#create-a-repeat-button).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RepeatButton in action](winui3gallery:/item/RepeatButton).
+> [Open the WinUI 3 Gallery app and see the RepeatButton in action](winui3gallery:/item/RepeatButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls.primitives/tabviewlistview.md
+++ b/microsoft.ui.xaml.controls.primitives/tabviewlistview.md
@@ -23,6 +23,6 @@ Represents the ListView corresponding to the TabStrip within the TabView.
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls.primitives/togglebutton.md
+++ b/microsoft.ui.xaml.controls.primitives/togglebutton.md
@@ -52,7 +52,7 @@ ToggleButton is the parent class for several immediately derived controls that t
 > For more info, design guidance, and code examples, see [Toggle switches](/windows/apps/design/controls/toggles).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ToggleButton in action](winui3gallery:/item/ToggleButton).
+> [Open the WinUI 3 Gallery app and see the ToggleButton in action](winui3gallery:/item/ToggleButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/animatedicon.md
+++ b/microsoft.ui.xaml.controls/animatedicon.md
@@ -96,7 +96,7 @@ In order to support XAML processor access to the attached properties, and also t
 > For more info, design guidance, and code examples, see [Animated icon](/windows/apps/design/controls/animated-icon).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AnimatedIcon in action](winui3gallery:/item/AnimatedIcon).
+> [Open the WinUI 3 Gallery app and see the AnimatedIcon in action](winui3gallery:/item/AnimatedIcon)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/animatediconsource.md
+++ b/microsoft.ui.xaml.controls/animatediconsource.md
@@ -26,7 +26,7 @@ You don't set the state directly on an `AnimatedIconSource`. Instead, set the [A
 > For more info, design guidance, and code examples, see [Animated icon](/windows/apps/design/controls/animated-icon).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AnimatedIcon in action](winui3gallery:/item/AnimatedIcon).
+> [Open the WinUI 3 Gallery app and see the AnimatedIcon in action](winui3gallery:/item/AnimatedIcon)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/animatedvisualplayer.md
+++ b/microsoft.ui.xaml.controls/animatedvisualplayer.md
@@ -24,6 +24,6 @@ The AnimatedVisualPlayer hosts and controls playback of an animated [Visual](../
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AnimatedVisualPlayer in action](winui3gallery:/item/AnimatedVisualPlayer).
+> [Open the WinUI 3 Gallery app and see the AnimatedVisualPlayer in action](winui3gallery:/item/AnimatedVisualPlayer)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/appbarbutton.md
+++ b/microsoft.ui.xaml.controls/appbarbutton.md
@@ -61,7 +61,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Command bar](/windows/uwp/controls-and-patterns/app-bars).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AppBarButton in action](winui3gallery:/item/AppBarButton).
+> [Open the WinUI 3 Gallery app and see the AppBarButton in action](winui3gallery:/item/AppBarButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/appbarseparator.md
+++ b/microsoft.ui.xaml.controls/appbarseparator.md
@@ -33,7 +33,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Command bar](/windows/uwp/controls-and-patterns/app-bars).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AppBarSeparator in action](winui3gallery:/item/AppBarSeparator).
+> [Open the WinUI 3 Gallery app and see the AppBarSeparator in action](winui3gallery:/item/AppBarSeparator)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/appbartogglebutton.md
+++ b/microsoft.ui.xaml.controls/appbartogglebutton.md
@@ -37,7 +37,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Command bar](/windows/uwp/controls-and-patterns/app-bars).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AppBarToggleButton in action](winui3gallery:/item/AppBarToggleButton).
+> [Open the WinUI 3 Gallery app and see the AppBarToggleButton in action](winui3gallery:/item/AppBarToggleButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/autosuggestbox.md
+++ b/microsoft.ui.xaml.controls/autosuggestbox.md
@@ -115,7 +115,7 @@ Resources that start with `TextControl` are shared by [TextBox](textbox.md), [Pa
 > For more info, design guidance, and code examples, see [Auto suggest box](/windows/apps/design/controls/auto-suggest-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AutoSuggestBox in action](winui3gallery:/item/AutoSuggestBox).
+> [Open the WinUI 3 Gallery app and see the AutoSuggestBox in action](winui3gallery:/item/AutoSuggestBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/bitmapicon.md
+++ b/microsoft.ui.xaml.controls/bitmapicon.md
@@ -44,7 +44,7 @@ You typically specify a [UriSource](bitmapicon_urisource.md) value that referenc
 > For more info, design guidance, and code examples, see [Command bar](/windows/uwp/controls-and-patterns/app-bars).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the BitmapIcon in action](winui3gallery:/item/AppBarButton).
+> [Open the WinUI 3 Gallery app and see the BitmapIcon in action](winui3gallery:/item/AppBarButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/bitmapiconsource.md
+++ b/microsoft.ui.xaml.controls/bitmapiconsource.md
@@ -26,7 +26,7 @@ Represents an icon source that uses a bitmap as its content.
 > For more info, design guidance, and code examples, see [Icons for Windows apps](/windows/apps/design/style/icons).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see BitmapIconSource in action](winui3gallery:/item/IconElement).
+> [Open the WinUI 3 Gallery app and see BitmapIconSource in action](winui3gallery:/item/IconElement)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/border.md
+++ b/microsoft.ui.xaml.controls/border.md
@@ -33,7 +33,7 @@ A Border can contain only one child object. If you want to put a border around m
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Border in action](winui3gallery:/item/Border).
+> [Open the WinUI 3 Gallery app and see the Border in action](winui3gallery:/item/Border)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/breadcrumbbar.md
+++ b/microsoft.ui.xaml.controls/breadcrumbbar.md
@@ -39,6 +39,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Breadcrumb Bar](/windows/apps/design/controls/breadcrumbbar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the BreadcrumbBar in action](winui3gallery:/item/BreadcrumbBar).
+> [Open the WinUI 3 Gallery app and see the BreadcrumbBar in action](winui3gallery:/item/BreadcrumbBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)

--- a/microsoft.ui.xaml.controls/button.md
+++ b/microsoft.ui.xaml.controls/button.md
@@ -61,7 +61,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Button](/windows/apps/design/controls/buttons).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Button in action](winui3gallery:/item/Button).
+> [Open the WinUI 3 Gallery app and see the Button in action](winui3gallery:/item/Button)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/calendardatepicker.md
+++ b/microsoft.ui.xaml.controls/calendardatepicker.md
@@ -101,7 +101,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Calendar Date Picker](/windows/apps/design/controls/calendar-date-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CalendarDatePicker in action](winui3gallery:/item/CalendarDatePicker).
+> [Open the WinUI 3 Gallery app and see the CalendarDatePicker in action](winui3gallery:/item/CalendarDatePicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/calendarview.md
+++ b/microsoft.ui.xaml.controls/calendarview.md
@@ -117,7 +117,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Calendar View](/windows/apps/design/controls/calendar-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CalendarView in action](winui3gallery:/item/CalendarView).
+> [Open the WinUI 3 Gallery app and see the CalendarView in action](winui3gallery:/item/CalendarView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/canvas.md
+++ b/microsoft.ui.xaml.controls/canvas.md
@@ -67,7 +67,7 @@ In order to support XAML processor access to the attached properties, and also t
 > For more info, design guidance, and code examples, see [Layout panels](/windows/apps/design/layout/layout-panels#canvas).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Canvas in action](winui3gallery:/item/Canvas).
+> [Open the WinUI 3 Gallery app and see the Canvas in action](winui3gallery:/item/Canvas)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/checkbox.md
+++ b/microsoft.ui.xaml.controls/checkbox.md
@@ -57,7 +57,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Checkbox](/windows/apps/design/controls/checkbox).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Checkbox in action](winui3gallery:/item/Checkbox).
+> [Open the WinUI 3 Gallery app and see the Checkbox in action](winui3gallery:/item/Checkbox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/colorchangedeventargs.md
+++ b/microsoft.ui.xaml.controls/colorchangedeventargs.md
@@ -24,6 +24,6 @@ Provides event data for a ColorChanged event (see [ColorPicker.ColorChanged](col
 > For more info, design guidance, and code examples, see [Color picker](/windows/apps/design/controls/color-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker).
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/colorpicker.md
+++ b/microsoft.ui.xaml.controls/colorpicker.md
@@ -36,7 +36,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Color Picker](/windows/apps/design/controls/color-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker).
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/colorpickerhsvchannel.md
+++ b/microsoft.ui.xaml.controls/colorpickerhsvchannel.md
@@ -42,6 +42,6 @@ The slider controls the Alpha channel.
 > For more info, design guidance, and code examples, see [Color picker](/windows/apps/design/controls/color-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker).
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/colorspectrumcomponents.md
+++ b/microsoft.ui.xaml.controls/colorspectrumcomponents.md
@@ -52,6 +52,6 @@ The order of the two components in each value indicates the X/Y axis when the sp
 > For more info, design guidance, and code examples, see [Color picker](/windows/apps/design/controls/color-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker).
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/colorspectrumshape.md
+++ b/microsoft.ui.xaml.controls/colorspectrumshape.md
@@ -34,6 +34,6 @@ The [ColorSpectrum](../microsoft.ui.xaml.controls.primitives/colorspectrum.md) c
 > For more info, design guidance, and code examples, see [Color picker](/windows/apps/design/controls/color-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker).
+> [Open the WinUI 3 Gallery app and see the ColorPicker in action](winui3gallery:/item/ColorPicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/combobox.md
+++ b/microsoft.ui.xaml.controls/combobox.md
@@ -48,7 +48,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Combo Box](/windows/apps/design/controls/combo-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ComboBox in action](winui3gallery:/item/ComboBox).
+> [Open the WinUI 3 Gallery app and see the ComboBox in action](winui3gallery:/item/ComboBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/comboboxitem.md
+++ b/microsoft.ui.xaml.controls/comboboxitem.md
@@ -39,7 +39,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Combo box](/windows/apps/design/controls/combo-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ComboBox in action](winui3gallery:/item/ComboBox).
+> [Open the WinUI 3 Gallery app and see the ComboBox in action](winui3gallery:/item/ComboBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/commandbar.md
+++ b/microsoft.ui.xaml.controls/commandbar.md
@@ -105,7 +105,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Command bar](/windows/apps/design/controls/command-bar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CommandBar in action](winui3gallery:/item/CommandBar).
+> [Open the WinUI 3 Gallery app and see the CommandBar in action](winui3gallery:/item/CommandBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/commandbarflyout.md
+++ b/microsoft.ui.xaml.controls/commandbarflyout.md
@@ -32,7 +32,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Command bar flyout](/windows/apps/design/controls/command-bar-flyout).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery:/item/CommandBarFlyout).
+> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery:/item/CommandBarFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/contentdialog.md
+++ b/microsoft.ui.xaml.controls/contentdialog.md
@@ -125,7 +125,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Dialog controls](/windows/apps/design/controls/dialogs-and-flyouts/dialogs).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ContentDialog in action](winui3gallery:/item/ContentDialog).
+> [Open the WinUI 3 Gallery app and see the ContentDialog in action](winui3gallery:/item/ContentDialog)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/datepicker.md
+++ b/microsoft.ui.xaml.controls/datepicker.md
@@ -84,7 +84,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Date Picker](/windows/apps/design/controls/date-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the DatePicker in action](winui3gallery:/item/DatePicker).
+> [Open the WinUI 3 Gallery app and see the DatePicker in action](winui3gallery:/item/DatePicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/dropdownbutton.md
+++ b/microsoft.ui.xaml.controls/dropdownbutton.md
@@ -34,7 +34,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Buttons](/windows/apps/design/controls/buttons#create-a-drop-down-button).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the DropDownButton in action](winui3gallery:/item/DropDownButton).
+> [Open the WinUI 3 Gallery app and see the DropDownButton in action](winui3gallery:/item/DropDownButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/expanddirection.md
+++ b/microsoft.ui.xaml.controls/expanddirection.md
@@ -41,6 +41,6 @@ This enumeration is used by the [Expander.ExpandDirection](expander_expanddirect
 > For more info, design guidance, and code examples, see [Expander](/windows/apps/design/controls/expander).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander).
+> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/expander.md
+++ b/microsoft.ui.xaml.controls/expander.md
@@ -43,6 +43,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Expander](/windows/apps/design/controls/expander).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander).
+> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/expander_expanddirection.md
+++ b/microsoft.ui.xaml.controls/expander_expanddirection.md
@@ -35,6 +35,6 @@ The [Expander](expander.md) control can expand `Up` or `Down`.
 > For more info, design guidance, and code examples, see [Expander](/windows/apps/design/controls/expander).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander).
+> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/expander_header.md
+++ b/microsoft.ui.xaml.controls/expander_header.md
@@ -35,6 +35,6 @@ The XAML content that is displayed in the header.
 > For more info, design guidance, and code examples, see [Expander](/windows/apps/design/controls/expander).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander).
+> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/expander_templatesettings.md
+++ b/microsoft.ui.xaml.controls/expander_templatesettings.md
@@ -33,6 +33,6 @@ An instance of `ExpanderTemplateSettings`.
 > For more info, design guidance, and code examples, see [Expander](/windows/apps/design/controls/expander).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander).
+> [Open the WinUI 3 Gallery app and see the Expander in action](winui3gallery:/item/Expander)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/flipview.md
+++ b/microsoft.ui.xaml.controls/flipview.md
@@ -53,7 +53,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Flipview](/windows/apps/design/controls/flipview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Flipview in action](winui3gallery:/item/Flipview).
+> [Open the WinUI 3 Gallery app and see the Flipview in action](winui3gallery:/item/Flipview)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/flyout.md
+++ b/microsoft.ui.xaml.controls/flyout.md
@@ -76,7 +76,7 @@ This example shows how to let the [FlyoutPresenter](flyoutpresenter.md) receive 
 > For more info, design guidance, and code examples, see [Flyout](/windows/apps/design/controls/dialogs-and-flyouts/flyouts).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Flyout in action](winui3gallery:/item/Flyout).
+> [Open the WinUI 3 Gallery app and see the Flyout in action](winui3gallery:/item/Flyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/fonticon.md
+++ b/microsoft.ui.xaml.controls/fonticon.md
@@ -46,7 +46,7 @@ If you use a `FontIcon` in an [AppBarButton](appbarbutton.md), you can set the `
 > For more info, design guidance, and code examples, see [Command bar](/windows/uwp/controls-and-patterns/app-bars).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see FontIcon in action](winui3gallery:/item/AppBarButton).
+> [Open the WinUI 3 Gallery app and see FontIcon in action](winui3gallery:/item/AppBarButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/fonticonsource.md
+++ b/microsoft.ui.xaml.controls/fonticonsource.md
@@ -24,7 +24,7 @@ Represents an icon source that uses a glyph from the specified font.
 > For more info, design guidance, and code examples, see [Icons for Windows apps](/windows/apps/design/style/icons).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see IconElement in action](winui3gallery:/item/IconElement).
+> [Open the WinUI 3 Gallery app and see IconElement in action](winui3gallery:/item/IconElement)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/frame.md
+++ b/microsoft.ui.xaml.controls/frame.md
@@ -39,7 +39,7 @@ The [INavigate](inavigate.md) interface is mainly infrastructure. It's not expec
 > For more info, design guidance, and code examples, see [Navigation design basics](/windows/apps/design/basics/navigation-basics).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see NavigationView and Frame in action](winui3gallery://item/NavigationView).
+> [Open the WinUI 3 Gallery app and see NavigationView and Frame in action](winui3gallery://item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/grid.md
+++ b/microsoft.ui.xaml.controls/grid.md
@@ -95,7 +95,7 @@ In order to support XAML processor access to the attached properties, and also t
 > For more info, design guidance, and code examples, see [Layout panels](/windows/apps/design/layout/layout-panels#grid).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Grid in action](winui3gallery:/item/Grid).
+> [Open the WinUI 3 Gallery app and see the Grid in action](winui3gallery:/item/Grid)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/gridview.md
+++ b/microsoft.ui.xaml.controls/gridview.md
@@ -105,7 +105,7 @@ List controls that derive from [Selector](../microsoft.ui.xaml.controls.primitiv
 > For more info, design guidance, and code examples, see [List view and grid view](/windows/apps/design/controls/listview-and-gridview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the GridView in action](winui3gallery:/item/GridView).
+> [Open the WinUI 3 Gallery app and see the GridView in action](winui3gallery:/item/GridView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/hyperlinkbutton.md
+++ b/microsoft.ui.xaml.controls/hyperlinkbutton.md
@@ -71,7 +71,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Hyperlinks](/windows/apps/design/controls/hyperlinks).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the HyperlinkButton in action](winui3gallery:/item/HyperlinkButton).
+> [Open the WinUI 3 Gallery app and see the HyperlinkButton in action](winui3gallery:/item/HyperlinkButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/iconsource.md
+++ b/microsoft.ui.xaml.controls/iconsource.md
@@ -33,6 +33,6 @@ Represents the base class for an icon source.
 > For more info, design guidance, and code examples, see [Icons for Windows apps](/windows/apps/design/style/icons).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the IconElement in action](winui3gallery:/item/IconElement).
+> [Open the WinUI 3 Gallery app and see the IconElement in action](winui3gallery:/item/IconElement)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/image.md
+++ b/microsoft.ui.xaml.controls/image.md
@@ -191,7 +191,7 @@ Resources can use a resource qualifier pattern to load different resources depen
 > For more info, design guidance, and code examples, see [Images and image brushes](/windows/apps/design/controls/images-imagebrushes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Image in action](winui3gallery:/item/Image).
+> [Open the WinUI 3 Gallery app and see the Image in action](winui3gallery:/item/Image)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/imageicon.md
+++ b/microsoft.ui.xaml.controls/imageicon.md
@@ -31,7 +31,7 @@ Due to the file types supported, `ImageIcon` ignores the [Foreground](iconelemen
 > For more info, design guidance, and code examples, see [Icons for Windows apps](/windows/apps/design/style/icons).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see IconElement in action](winui3gallery:/item/IconElement).
+> [Open the WinUI 3 Gallery app and see IconElement in action](winui3gallery:/item/IconElement)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/imageiconsource.md
+++ b/microsoft.ui.xaml.controls/imageiconsource.md
@@ -23,7 +23,7 @@ ImageIconSource is similar to [ImageIcon](imageicon.md). However, because it is 
 > For more info, design guidance, and code examples, see [Icons for Windows apps](/windows/apps/design/style/icons).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see IconElement in action](winui3gallery:/item/IconElement).
+> [Open the WinUI 3 Gallery app and see IconElement in action](winui3gallery:/item/IconElement)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/infobar.md
+++ b/microsoft.ui.xaml.controls/infobar.md
@@ -34,6 +34,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [InfoBar](/windows/apps/design/controls/infobar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar).
+> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/infobar_content.md
+++ b/microsoft.ui.xaml.controls/infobar_content.md
@@ -30,6 +30,6 @@ The content is shown in its own line below the [Title](infobar_title.md) and [Me
 > For more info, design guidance, and code examples, see [InfoBar](/windows/apps/design/controls/infobar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar).
+> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/infobar_severity.md
+++ b/microsoft.ui.xaml.controls/infobar_severity.md
@@ -30,6 +30,6 @@ The style of the `InfoBar` that indicates the criticality of the notification. T
 > For more info, design guidance, and code examples, see [InfoBar](/windows/apps/design/controls/infobar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar).
+> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/infobar_templatesettings.md
+++ b/microsoft.ui.xaml.controls/infobar_templatesettings.md
@@ -28,6 +28,6 @@ An object that provides calculated values for templates.
 > For more info, design guidance, and code examples, see [InfoBar](/windows/apps/design/controls/infobar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar).
+> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/infobarseverity.md
+++ b/microsoft.ui.xaml.controls/infobarseverity.md
@@ -44,6 +44,6 @@ Communicates that the InfoBar is displaying information regarding an error or pr
 > For more info, design guidance, and code examples, see [InfoBar](/windows/apps/design/controls/infobar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar).
+> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/infobartemplatesettings.md
+++ b/microsoft.ui.xaml.controls/infobartemplatesettings.md
@@ -26,6 +26,6 @@ Provides calculated values that can be referenced as **TemplatedParent** sources
 > For more info, design guidance, and code examples, see [InfoBar](/windows/apps/design/controls/infobar).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar).
+> [Open the WinUI 3 Gallery app and see the InfoBar in action](winui3gallery:/item/InfoBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/itemsrepeater.md
+++ b/microsoft.ui.xaml.controls/itemsrepeater.md
@@ -25,7 +25,7 @@ ItemsRepeater supports virtualization when attached to a host that supports virt
 > For more info, design guidance, and code examples, see [Items repeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/itemsrepeaterelementclearingeventargs.md
+++ b/microsoft.ui.xaml.controls/itemsrepeaterelementclearingeventargs.md
@@ -27,6 +27,6 @@ Elements are _cleared_ when they become available for re-use.
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/itemsrepeaterelementindexchangedeventargs.md
+++ b/microsoft.ui.xaml.controls/itemsrepeaterelementindexchangedeventargs.md
@@ -25,6 +25,6 @@ Provides data for the ItemsRepeater.ElementIndexChanged event.
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/itemsrepeaterelementpreparedeventargs.md
+++ b/microsoft.ui.xaml.controls/itemsrepeaterelementpreparedeventargs.md
@@ -25,6 +25,6 @@ Provides data for the ItemsRepeater.ElementPrepared event.
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/itemsrepeaterscrollhost.md
+++ b/microsoft.ui.xaml.controls/itemsrepeaterscrollhost.md
@@ -30,7 +30,7 @@ If the minimum target version of your app is Windows 10, version 1809 (SDK 17763
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/itemssourceview.md
+++ b/microsoft.ui.xaml.controls/itemssourceview.md
@@ -27,6 +27,6 @@ Components written to work with [ItemsRepeater](itemsrepeater.md) should consume
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/listbox.md
+++ b/microsoft.ui.xaml.controls/listbox.md
@@ -55,7 +55,7 @@ ListBox has many similarities with [ListView](listview.md) or [GridView](gridvie
 > For more info, design guidance, and code examples, see [Lists](/windows/apps/design/controls/lists#list-boxes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ListBox in action](winui3gallery:/item/ListBox).
+> [Open the WinUI 3 Gallery app and see the ListBox in action](winui3gallery:/item/ListBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/listboxitem.md
+++ b/microsoft.ui.xaml.controls/listboxitem.md
@@ -32,7 +32,7 @@ You can specify the look of the ListBoxItem by setting the [ListBox](listbox.md)
 > For more info, design guidance, and code examples, see [List boxes](/windows/apps/design/controls/lists#list-boxes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ListBox in action](winui3gallery:/item/ListBox).
+> [Open the WinUI 3 Gallery app and see the ListBox in action](winui3gallery:/item/ListBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/listview.md
+++ b/microsoft.ui.xaml.controls/listview.md
@@ -79,7 +79,7 @@ List controls that derive from [Selector](../microsoft.ui.xaml.controls.primitiv
 > For more info, design guidance, and code examples, see [List view and grid view](/windows/apps/design/controls/listview-and-gridview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ListView in action](winui3gallery:/item/ListView).
+> [Open the WinUI 3 Gallery app and see the ListView in action](winui3gallery:/item/ListView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/menubar.md
+++ b/microsoft.ui.xaml.controls/menubar.md
@@ -30,6 +30,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Menu flyout and menu bar](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuBar in action](winui3gallery:/item/MenuBar).
+> [Open the WinUI 3 Gallery app and see the MenuBar in action](winui3gallery:/item/MenuBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/menubaritem.md
+++ b/microsoft.ui.xaml.controls/menubaritem.md
@@ -24,6 +24,6 @@ Represents a top-level menu in a [MenuBar](menubar.md) control.
 > For more info, design guidance, and code examples, see [Menu flyout and menu bar](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuBar in action](winui3gallery:/item/MenuBar).
+> [Open the WinUI 3 Gallery app and see the MenuBar in action](winui3gallery:/item/MenuBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/menubaritemflyout.md
+++ b/microsoft.ui.xaml.controls/menubaritemflyout.md
@@ -24,6 +24,6 @@ Represents the flyout of a [MenuBarItem](menubaritem.md).
 > For more info, design guidance, and code examples, see [Menu flyout and menu bar](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuBar in action](winui3gallery:/item/MenuBar).
+> [Open the WinUI 3 Gallery app and see the MenuBar in action](winui3gallery:/item/MenuBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/menuflyout.md
+++ b/microsoft.ui.xaml.controls/menuflyout.md
@@ -50,7 +50,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Menus and context menus](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout).
+> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/menuflyoutitem.md
+++ b/microsoft.ui.xaml.controls/menuflyoutitem.md
@@ -41,7 +41,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Menus and context menus](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout).
+> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/menuflyoutseparator.md
+++ b/microsoft.ui.xaml.controls/menuflyoutseparator.md
@@ -31,7 +31,7 @@ There are three elements that you can use to compose the menu items in a [MenuFl
 > For more info, design guidance, and code examples, see [Menus and context menus](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout).
+> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/microsoft_ui_xaml_controls.md
+++ b/microsoft.ui.xaml.controls/microsoft_ui_xaml_controls.md
@@ -23,6 +23,6 @@ Provides UI controls and classes for creating custom controls.
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the  in action](winui3gallery:).
+> [Open the WinUI 3 Gallery app and see the  in action](winui3gallery:)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/navigationview.md
+++ b/microsoft.ui.xaml.controls/navigationview.md
@@ -89,7 +89,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Navigation View](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/navigationviewbackbuttonvisible.md
+++ b/microsoft.ui.xaml.controls/navigationviewbackbuttonvisible.md
@@ -36,6 +36,6 @@ The system chooses whether or not to display the back button, depending on the d
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/navigationviewbackrequestedeventargs.md
+++ b/microsoft.ui.xaml.controls/navigationviewbackrequestedeventargs.md
@@ -22,7 +22,7 @@ Provides event data for the [NavigationView.BackRequested](navigationview_backre
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewdisplaymode.md
+++ b/microsoft.ui.xaml.controls/navigationviewdisplaymode.md
@@ -36,7 +36,7 @@ The pane always shows as a narrow sliver which can be opened to full width.
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewdisplaymodechangedeventargs.md
+++ b/microsoft.ui.xaml.controls/navigationviewdisplaymodechangedeventargs.md
@@ -22,7 +22,7 @@ Provides data for the [NavigationView.DisplayModeChanged](navigationview_display
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewitem.md
+++ b/microsoft.ui.xaml.controls/navigationviewitem.md
@@ -24,7 +24,7 @@ Note that you can only place **NavigationViewItems** in **NavigationView.MenuIte
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewitembase.md
+++ b/microsoft.ui.xaml.controls/navigationviewitembase.md
@@ -22,7 +22,7 @@ Base class for [NavigationView](navigationview.md) menu items.
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewitemcollapsedeventargs.md
+++ b/microsoft.ui.xaml.controls/navigationviewitemcollapsedeventargs.md
@@ -23,7 +23,7 @@ Provides event data for the [NavigationViewItem.Collapsed](navigationview_collap
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewitemexpandingeventargs.md
+++ b/microsoft.ui.xaml.controls/navigationviewitemexpandingeventargs.md
@@ -24,7 +24,7 @@ Provides event data for the [NavigationViewItem.Expanding](navigationview_collap
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewitemheader.md
+++ b/microsoft.ui.xaml.controls/navigationviewitemheader.md
@@ -22,7 +22,7 @@ Represents a header for a group of menu items in a [NavigationView](navigationvi
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewitemseparator.md
+++ b/microsoft.ui.xaml.controls/navigationviewitemseparator.md
@@ -22,7 +22,7 @@ Represents a line that separates menu items in a [NavigationView](navigationview
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewoverflowlabelmode.md
+++ b/microsoft.ui.xaml.controls/navigationviewoverflowlabelmode.md
@@ -34,7 +34,7 @@ The overflow menu is shown only when [NavigationView.PaneDisplayMode](navigation
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewpaneclosingeventargs.md
+++ b/microsoft.ui.xaml.controls/navigationviewpaneclosingeventargs.md
@@ -22,7 +22,7 @@ Provides data for the [NavigationView.PaneClosing](navigationview_paneclosing.md
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewpanedisplaymode.md
+++ b/microsoft.ui.xaml.controls/navigationviewpanedisplaymode.md
@@ -46,7 +46,7 @@ The pane is shown on the left side of the control, and changes between minimal, 
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewselectionchangedeventargs.md
+++ b/microsoft.ui.xaml.controls/navigationviewselectionchangedeventargs.md
@@ -22,7 +22,7 @@ Provides data for the [NavigationView.SelectionChanged](navigationview_selection
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewselectionfollowsfocus.md
+++ b/microsoft.ui.xaml.controls/navigationviewselectionfollowsfocus.md
@@ -32,7 +32,7 @@ Selection does not change when keyboard focus changes.
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewshouldernavigationenabled.md
+++ b/microsoft.ui.xaml.controls/navigationviewshouldernavigationenabled.md
@@ -38,7 +38,7 @@ Game controller bumpers always navigate the top-level navigation items.
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/navigationviewtemplatesettings.md
+++ b/microsoft.ui.xaml.controls/navigationviewtemplatesettings.md
@@ -22,7 +22,7 @@ Provides calculated values that can be referenced as **TemplatedParent** sources
 > For more info, design guidance, and code examples, see [NavigationView](/windows/apps/design/controls/navigationview).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView).
+> [Open the WinUI 3 Gallery app and see the NavigationView in action](winui3gallery:/item/NavigationView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/numberbox.md
+++ b/microsoft.ui.xaml.controls/numberbox.md
@@ -33,6 +33,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Number box](/windows/apps/design/controls/number-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox).
+> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)

--- a/microsoft.ui.xaml.controls/numberboxspinbuttonplacementmode.md
+++ b/microsoft.ui.xaml.controls/numberboxspinbuttonplacementmode.md
@@ -41,6 +41,6 @@ The spin buttons are displayed in an expanded, horizontal orientation.
 > For more info, design guidance, and code examples, see [Number box](/windows/apps/design/controls/number-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox).
+> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/numberboxvalidationmode.md
+++ b/microsoft.ui.xaml.controls/numberboxvalidationmode.md
@@ -33,6 +33,6 @@ Invalid input is replaced by [NumberBox.PlaceholderText](numberbox_placeholderte
 > For more info, design guidance, and code examples, see [Number box](/windows/apps/design/controls/number-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox).
+> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/numberboxvaluechangedeventargs.md
+++ b/microsoft.ui.xaml.controls/numberboxvaluechangedeventargs.md
@@ -25,6 +25,6 @@ Provides event data for the [NumberBox.ValueChanged](numberbox_valuechanged.md) 
 > For more info, design guidance, and code examples, see [Number box](/windows/apps/design/controls/number-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox).
+> [Open the WinUI 3 Gallery app and see the NumberBox in action](winui3gallery:/item/NumberBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/parallaxsourceoffsetkind.md
+++ b/microsoft.ui.xaml.controls/parallaxsourceoffsetkind.md
@@ -34,6 +34,6 @@ The source start/end offset value is interpreted as an absolute value.
 > For more info, design guidance, and code examples, see [Parallax](/windows/apps/design/motion/parallax).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ParallaxView in action](winui3gallery:/item/ParallaxView).
+> [Open the WinUI 3 Gallery app and see the ParallaxView in action](winui3gallery:/item/ParallaxView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/parallaxview.md
+++ b/microsoft.ui.xaml.controls/parallaxview.md
@@ -24,7 +24,7 @@ Represents a container that associates the scroll position of a foreground eleme
 > For more info, design guidance, and code examples, see [Parallax](/windows/apps/design/motion/parallax).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ParallaxView in action](winui3gallery:/item/ParallaxView).
+> [Open the WinUI 3 Gallery app and see the ParallaxView in action](winui3gallery:/item/ParallaxView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/passwordbox.md
+++ b/microsoft.ui.xaml.controls/passwordbox.md
@@ -60,7 +60,7 @@ Resources that start with `TextControl` are shared by [TextBox](textbox.md), `Pa
 > For more info, design guidance, and code examples, see [Password box](/windows/apps/design/controls/password-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the PasswordBox in action](winui3gallery:/item/PasswordBox).
+> [Open the WinUI 3 Gallery app and see the PasswordBox in action](winui3gallery:/item/PasswordBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/pathicon.md
+++ b/microsoft.ui.xaml.controls/pathicon.md
@@ -30,7 +30,7 @@ Represents an icon that uses a vector path as its content.
 > For more info, design guidance, and code examples, see [Command bar](/windows/uwp/controls-and-patterns/app-bars).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AppBarButton in action](winui3gallery:/item/AppBarButton).
+> [Open the WinUI 3 Gallery app and see the AppBarButton in action](winui3gallery:/item/AppBarButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/pathiconsource.md
+++ b/microsoft.ui.xaml.controls/pathiconsource.md
@@ -26,7 +26,7 @@ Represents an icon source that uses a vector path as its content.
 > For more info, design guidance, and code examples, see [Icons for Windows apps](/windows/apps/design/style/icons).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the IconElement in action](winui3gallery:/item/IconElement).
+> [Open the WinUI 3 Gallery app and see the IconElement in action](winui3gallery:/item/IconElement)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/personpicture.md
+++ b/microsoft.ui.xaml.controls/personpicture.md
@@ -30,7 +30,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Person picture](/windows/apps/design/controls/person-picture).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the PersonPicture in action](winui3gallery:/item/PersonPicture).
+> [Open the WinUI 3 Gallery app and see the PersonPicture in action](winui3gallery:/item/PersonPicture)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/personpicture_templatesettings.md
+++ b/microsoft.ui.xaml.controls/personpicture_templatesettings.md
@@ -29,6 +29,6 @@ An object that provides calculated values for templates.
 > For more info, design guidance, and code examples, see [Person picture](/windows/apps/design/controls/person-picture).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the PersonPicture in action](winui3gallery:/item/PersonPicture).
+> [Open the WinUI 3 Gallery app and see the PersonPicture in action](winui3gallery:/item/PersonPicture)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/pipspager.md
+++ b/microsoft.ui.xaml.controls/pipspager.md
@@ -35,7 +35,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Pipspager](/windows/apps/design/controls/pipspager).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Pipspager in action](winui3gallery:/item/Pipspager).
+> [Open the WinUI 3 Gallery app and see the Pipspager in action](winui3gallery:/item/Pipspager)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/pipspager_templatesettings.md
+++ b/microsoft.ui.xaml.controls/pipspager_templatesettings.md
@@ -29,6 +29,6 @@ An object that provides calculated values for templates.
 > For more info, design guidance, and code examples, see [PipsPager](/windows/apps/design/controls/pipspager).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery:/item/PipsPager).
+> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery:/item/PipsPager)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/pipspagerbuttonvisibility.md
+++ b/microsoft.ui.xaml.controls/pipspagerbuttonvisibility.md
@@ -39,6 +39,6 @@ The button is not visible and does not take up layout space.
 > For more info, design guidance, and code examples, see [PipsPager](/windows/apps/design/controls/pipspager).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery:/item/PipsPager).
+> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery:/item/PipsPager)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/pipspagertemplatesettings.md
+++ b/microsoft.ui.xaml.controls/pipspagertemplatesettings.md
@@ -25,6 +25,6 @@ Provides calculated values that can be referenced as **TemplatedParent** sources
 > For more info, design guidance, and code examples, see [PipsPager](/windows/apps/design/controls/pipspager).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery:/item/PipsPager).
+> [Open the WinUI 3 Gallery app and see the PipsPager in action](winui3gallery:/item/PipsPager)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/pivot.md
+++ b/microsoft.ui.xaml.controls/pivot.md
@@ -65,7 +65,7 @@ In order to support XAML processor access to the attached properties, and also t
 > For more info, design guidance, and code examples, see [Pivot](/windows/apps/design/controls/pivot).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Pivot in action](winui3gallery:/item/Pivot).
+> [Open the WinUI 3 Gallery app and see the Pivot in action](winui3gallery:/item/Pivot)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/progressbar.md
+++ b/microsoft.ui.xaml.controls/progressbar.md
@@ -40,7 +40,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Progress controls](/windows/apps/design/controls/progress-controls).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ProgressBar in action](winui3gallery:/item/ProgressBar).
+> [Open the WinUI 3 Gallery app and see the ProgressBar in action](winui3gallery:/item/ProgressBar)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/progressring.md
+++ b/microsoft.ui.xaml.controls/progressring.md
@@ -42,7 +42,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Progress controls](/windows/apps/design/controls/progress-controls).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ProgressRing in action](winui3gallery:/item/ProgressRing).
+> [Open the WinUI 3 Gallery app and see the ProgressRing in action](winui3gallery:/item/ProgressRing)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/radiobutton.md
+++ b/microsoft.ui.xaml.controls/radiobutton.md
@@ -46,7 +46,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Radio button](/windows/apps/design/controls/radio-button).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RadioButton in action](winui3gallery:/item/RadioButton).
+> [Open the WinUI 3 Gallery app and see the RadioButton in action](winui3gallery:/item/RadioButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/radiobuttons.md
+++ b/microsoft.ui.xaml.controls/radiobuttons.md
@@ -45,6 +45,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Radio buttons](/windows/apps/design/controls/radio-button).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see RadioButtons in action](winui3gallery:/item/RadioButtons).
+> [Open the WinUI 3 Gallery app and see RadioButtons in action](winui3gallery:/item/RadioButtons)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/radiomenuflyoutitem.md
+++ b/microsoft.ui.xaml.controls/radiomenuflyoutitem.md
@@ -35,7 +35,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Menu flyout and menu bar](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout).
+> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/ratingcontrol.md
+++ b/microsoft.ui.xaml.controls/ratingcontrol.md
@@ -30,7 +30,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Rating control](/windows/apps/design/controls/rating).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RatingControl in action](winui3gallery:/item/RatingControl).
+> [Open the WinUI 3 Gallery app and see the RatingControl in action](winui3gallery:/item/RatingControl)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/refreshcontainer.md
+++ b/microsoft.ui.xaml.controls/refreshcontainer.md
@@ -30,6 +30,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Pull to refresh](/windows/apps/design/controls/pull-to-refresh).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh).
+> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/refreshinteractionratiochangedeventargs.md
+++ b/microsoft.ui.xaml.controls/refreshinteractionratiochangedeventargs.md
@@ -24,6 +24,6 @@ Provides event data.
 > For more info, design guidance, and code examples, see [Pull to refresh](/windows/apps/design/controls/pull-to-refresh).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh).
+> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/refreshpulldirection.md
+++ b/microsoft.ui.xaml.controls/refreshpulldirection.md
@@ -44,6 +44,6 @@ This enumeration provides values for the [RefreshContainer.PullDirection](refres
 > For more info, design guidance, and code examples, see [Pull to refresh](/windows/apps/design/controls/pull-to-refresh).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh).
+> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/refreshrequestedeventargs.md
+++ b/microsoft.ui.xaml.controls/refreshrequestedeventargs.md
@@ -24,6 +24,6 @@ Provides event data for [RefreshRequested](#-see-also) events.
 > For more info, design guidance, and code examples, see [Pull to refresh](/windows/apps/design/controls/pull-to-refresh).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh).
+> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/refreshstatechangedeventargs.md
+++ b/microsoft.ui.xaml.controls/refreshstatechangedeventargs.md
@@ -24,6 +24,6 @@ Provides event data for the [RefreshVisualizer.RefreshStateChanged](refreshvisua
 > For more info, design guidance, and code examples, see [Pull to refresh](/windows/apps/design/controls/pull-to-refresh).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh).
+> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/refreshvisualizer.md
+++ b/microsoft.ui.xaml.controls/refreshvisualizer.md
@@ -30,6 +30,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Pull to refresh](/windows/apps/design/controls/pull-to-refresh).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh).
+> [Open the WinUI 3 Gallery app and see Pull-To-Refresh in action](winui3gallery:/item/PullToRefresh)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/relativepanel.md
+++ b/microsoft.ui.xaml.controls/relativepanel.md
@@ -133,7 +133,7 @@ In order to support XAML processor access to the attached properties, and also t
 > For more info, design guidance, and code examples, see [Layout panels](/windows/apps/design/layout/layout-panels#relativepanel).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RelativePanel in action](winui3gallery:/item/RelativePanel).
+> [Open the WinUI 3 Gallery app and see the RelativePanel in action](winui3gallery:/item/RelativePanel)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/richeditbox.md
+++ b/microsoft.ui.xaml.controls/richeditbox.md
@@ -53,7 +53,7 @@ Resources that start with `TextControl` are shared by [TextBox](textbox.md), [Pa
 > For more info, design guidance, and code examples, see [Rich edit box](/windows/apps/design/controls/rich-edit-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RichEditBox in action](winui3gallery:/item/RichEditBox).
+> [Open the WinUI 3 Gallery app and see the RichEditBox in action](winui3gallery:/item/RichEditBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/richeditbox_contextmenuopening.md
+++ b/microsoft.ui.xaml.controls/richeditbox_contextmenuopening.md
@@ -27,7 +27,7 @@ To override or add commands to the context menu, you can handle the ContextMenuO
 > For more info, design guidance, and code examples, see [Rich edit box](/windows/apps/design/controls/rich-edit-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RichEditBox in action](winui3gallery:/item/RichEditBox).
+> [Open the WinUI 3 Gallery app and see the RichEditBox in action](winui3gallery:/item/RichEditBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/richtextblock.md
+++ b/microsoft.ui.xaml.controls/richtextblock.md
@@ -57,7 +57,7 @@ The default [FontFamily](richtextblock_fontfamily.md) for RichTextBlock is Segoe
 > For more info, design guidance, and code examples, see [Rich text block](/windows/apps/design/controls/rich-text-block).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RichTextBlock in action](winui3gallery:/item/RichTextBlock).
+> [Open the WinUI 3 Gallery app and see the RichTextBlock in action](winui3gallery:/item/RichTextBlock)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/scrollviewer.md
+++ b/microsoft.ui.xaml.controls/scrollviewer.md
@@ -150,7 +150,7 @@ When the OSK appears, the system adjusts app UI/layout behavior and provides scr
 > For more info, design guidance, and code examples, see [Scroll viewer controls](/windows/apps/design/controls/scroll-controls).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ScrollViewer in action](winui3gallery:/item/ScrollViewer).
+> [Open the WinUI 3 Gallery app and see the ScrollViewer in action](winui3gallery:/item/ScrollViewer)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/semanticzoom.md
+++ b/microsoft.ui.xaml.controls/semanticzoom.md
@@ -55,7 +55,7 @@ When you use a [GridView](gridview.md) in a SemanticZoom control, always set the
 > For more info, design guidance, and code examples, see [Semantic Zoom](/windows/apps/design/controls/semantic-zoom).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SemanticZoom in action](winui3gallery:/item/SemanticZoom).
+> [Open the WinUI 3 Gallery app and see the SemanticZoom in action](winui3gallery:/item/SemanticZoom)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/slider.md
+++ b/microsoft.ui.xaml.controls/slider.md
@@ -52,7 +52,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Slider](/windows/apps/design/controls/slider).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Slider in action](winui3gallery:/item/Slider).
+> [Open the WinUI 3 Gallery app and see the Slider in action](winui3gallery:/item/Slider)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/splitbutton.md
+++ b/microsoft.ui.xaml.controls/splitbutton.md
@@ -30,6 +30,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Buttons](/windows/apps/design/controls/buttons#create-a-split-button).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SplitButton in action](winui3gallery:/item/SplitButton).
+> [Open the WinUI 3 Gallery app and see the SplitButton in action](winui3gallery:/item/SplitButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/splitbuttonclickeventargs.md
+++ b/microsoft.ui.xaml.controls/splitbuttonclickeventargs.md
@@ -24,6 +24,6 @@ Provides event data for the [SplitButton.Click](splitbutton_click.md).
 > For more info, design guidance, and code examples, see [Buttons](/windows/apps/design/controls/buttons#create-a-split-button).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SplitButton in action](winui3gallery:/item/SplitButton).
+> [Open the WinUI 3 Gallery app and see the SplitButton in action](winui3gallery:/item/SplitButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/splitview.md
+++ b/microsoft.ui.xaml.controls/splitview.md
@@ -54,7 +54,7 @@ Set the [DisplayMode](splitview_displaymode.md) property to configure the intera
 > For more info, design guidance, and code examples, see [Split view](/windows/apps/design/controls/split-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SplitView in action](winui3gallery:/item/SplitView).
+> [Open the WinUI 3 Gallery app and see the SplitView in action](winui3gallery:/item/SplitView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/stackpanel.md
+++ b/microsoft.ui.xaml.controls/stackpanel.md
@@ -52,7 +52,7 @@ StackPanel defines border properties that let you draw a border around the Stack
 > For more info, design guidance, and code examples, see [Layout panels](/windows/apps/design/layout/layout-panels#stackpanel).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the StackPanel in action](winui3gallery:/item/StackPanel).
+> [Open the WinUI 3 Gallery app and see the StackPanel in action](winui3gallery:/item/StackPanel)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/swipebehavioroninvoked.md
+++ b/microsoft.ui.xaml.controls/swipebehavioroninvoked.md
@@ -38,6 +38,6 @@ In **Reveal** mode, the SwipeControl closes after an item is invoked. In **Execu
 > For more info, design guidance, and code examples, see [Swipe](/windows/apps/design/controls/swipe).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl).
+> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/swipecontrol.md
+++ b/microsoft.ui.xaml.controls/swipecontrol.md
@@ -34,7 +34,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Swipe](/windows/apps/design/controls/swipe).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl).
+> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/swipeitem.md
+++ b/microsoft.ui.xaml.controls/swipeitem.md
@@ -24,7 +24,7 @@ Represents an individual command in a [SwipeControl](swipecontrol.md).
 > For more info, design guidance, and code examples, see [Swipe](/windows/apps/design/controls/swipe).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl).
+> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/swipeitems.md
+++ b/microsoft.ui.xaml.controls/swipeitems.md
@@ -27,7 +27,7 @@ Represents a collection of [SwipeItem](swipeitem.md) objects.
 > For more info, design guidance, and code examples, see [Swipe](/windows/apps/design/controls/swipe).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl).
+> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/swipemode.md
+++ b/microsoft.ui.xaml.controls/swipemode.md
@@ -36,6 +36,6 @@ This enumeration is used by the [SwipeItems.Mode](swipeitems_mode.md) property.
 > For more info, design guidance, and code examples, see [Swipe](/windows/apps/design/controls/swipe).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl).
+> [Open the WinUI 3 Gallery app and see the SwipeControl in action](winui3gallery:/item/SwipeControl)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/symbolicon.md
+++ b/microsoft.ui.xaml.controls/symbolicon.md
@@ -38,7 +38,7 @@ If you use a `SymbolIcon` in an [AppBarButton](appbarbutton.md), you can set the
 > For more info, design guidance, and code examples, see [Command bar](/windows/uwp/controls-and-patterns/app-bars).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SymbolIcon in action](winui3gallery:/item/AppBarButton).
+> [Open the WinUI 3 Gallery app and see the SymbolIcon in action](winui3gallery:/item/AppBarButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/tabview.md
+++ b/microsoft.ui.xaml.controls/tabview.md
@@ -37,7 +37,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Tab view](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/tabview_tabdroppedoutside.md
+++ b/microsoft.ui.xaml.controls/tabview_tabdroppedoutside.md
@@ -31,7 +31,7 @@ If your app targets Windows 10 versions less than 1903, you will need to use Cor
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/tabviewclosebuttonoverlaymode.md
+++ b/microsoft.ui.xaml.controls/tabviewclosebuttonoverlaymode.md
@@ -43,6 +43,6 @@ Selected TabViewItems that are closable always show their close button regardles
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/tabviewitem.md
+++ b/microsoft.ui.xaml.controls/tabviewitem.md
@@ -27,7 +27,7 @@ A TabViewItem contains both the elements within the tab's header as well as the 
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/tabviewtabcloserequestedeventargs.md
+++ b/microsoft.ui.xaml.controls/tabviewtabcloserequestedeventargs.md
@@ -25,6 +25,6 @@ Provides data for a tab close event.
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/tabviewtabdragcompletedeventargs.md
+++ b/microsoft.ui.xaml.controls/tabviewtabdragcompletedeventargs.md
@@ -25,6 +25,6 @@ Provides data for the [TabView.TabDragCompleted](tabview_tabdragcompleted.md) ev
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/tabviewtabdragstartingeventargs.md
+++ b/microsoft.ui.xaml.controls/tabviewtabdragstartingeventargs.md
@@ -25,6 +25,6 @@ Provides data for the [TabView.TabDragStarting](tabview_tabdragstarting.md) even
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/tabviewtabdroppedoutsideeventargs.md
+++ b/microsoft.ui.xaml.controls/tabviewtabdroppedoutsideeventargs.md
@@ -25,6 +25,6 @@ Provides data for the [TabView.TabDroppedOutside](tabview_tabdroppedoutside.md) 
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/tabviewwidthmode.md
+++ b/microsoft.ui.xaml.controls/tabviewwidthmode.md
@@ -39,6 +39,6 @@ Each tab adjusts its width to the content within the tab.
 > For more info, design guidance, and code examples, see [TabView](/windows/apps/design/controls/tab-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView).
+> [Open the WinUI 3 Gallery app and see the TabView in action](winui3gallery:/item/TabView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/teachingtip.md
+++ b/microsoft.ui.xaml.controls/teachingtip.md
@@ -33,7 +33,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Teaching tip](/windows/apps/design/controls/dialogs-and-flyouts/teaching-tip).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip).
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/teachingtipclosedeventargs.md
+++ b/microsoft.ui.xaml.controls/teachingtipclosedeventargs.md
@@ -25,6 +25,6 @@ Provides data for the [TeachingTip.Closed](teachingtip_closed.md) event.
 > For more info, design guidance, and code examples, see [Teaching tip](/windows/apps/design/controls/dialogs-and-flyouts/teaching-tip).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip).
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/teachingtipclosereason.md
+++ b/microsoft.ui.xaml.controls/teachingtipclosereason.md
@@ -39,6 +39,6 @@ The teaching tip was programmatically closed.
 > For more info, design guidance, and code examples, see [Teaching tip](/windows/apps/design/controls/dialogs-and-flyouts/teaching-tip).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip).
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/teachingtipclosingeventargs.md
+++ b/microsoft.ui.xaml.controls/teachingtipclosingeventargs.md
@@ -25,6 +25,6 @@ Provides data for the [TeachingTip.Closing](teachingtip_closing.md) event.
 > For more info, design guidance, and code examples, see [Teaching tip](/windows/apps/design/controls/dialogs-and-flyouts/teaching-tip).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip).
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/teachingtipherocontentplacementmode.md
+++ b/microsoft.ui.xaml.controls/teachingtipherocontentplacementmode.md
@@ -41,6 +41,6 @@ The header of the teaching tip.
 > For more info, design guidance, and code examples, see [Teaching tip](/windows/apps/design/controls/dialogs-and-flyouts/teaching-tip).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip).
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/teachingtipplacementmode.md
+++ b/microsoft.ui.xaml.controls/teachingtipplacementmode.md
@@ -83,6 +83,6 @@ The top right corner of the xaml root when non-targeted and above the target ele
 > For more info, design guidance, and code examples, see [Teaching tip](/windows/apps/design/controls/dialogs-and-flyouts/teaching-tip).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip).
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/teachingtiptailvisibility.md
+++ b/microsoft.ui.xaml.controls/teachingtiptailvisibility.md
@@ -39,6 +39,6 @@ The teaching tip's tail is visible.
 > For more info, design guidance, and code examples, see [Teaching tip](/windows/apps/design/controls/dialogs-and-flyouts/teaching-tip).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip).
+> [Open the WinUI 3 Gallery app and see the TeachingTip in action](winui3gallery:/item/TeachingTip)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/textblock.md
+++ b/microsoft.ui.xaml.controls/textblock.md
@@ -76,7 +76,7 @@ The rendered text looks like this:
 > For more info, design guidance, and code examples, see [Text block](/windows/apps/design/controls/text-block).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TextBlock in action](winui3gallery:/item/TextBlock).
+> [Open the WinUI 3 Gallery app and see the TextBlock in action](winui3gallery:/item/TextBlock)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/textbox.md
+++ b/microsoft.ui.xaml.controls/textbox.md
@@ -188,7 +188,7 @@ Resources that start with `TextControl` are shared by `TextBox`, [PasswordBox](p
 > For more info, design guidance, and code examples, see [Text box](/windows/apps/design/controls/text-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TextBox in action](winui3gallery:/item/TextBox).
+> [Open the WinUI 3 Gallery app and see the TextBox in action](winui3gallery:/item/TextBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/textbox_contextmenuopening.md
+++ b/microsoft.ui.xaml.controls/textbox_contextmenuopening.md
@@ -29,7 +29,7 @@ To override or add commands to the context menu, you can handle the ContextMenuO
 > For more info, design guidance, and code examples, see [Text box](/windows/apps/design/controls/text-box).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TextBox in action](winui3gallery:/item/TextBox).
+> [Open the WinUI 3 Gallery app and see the TextBox in action](winui3gallery:/item/TextBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/textcommandbarflyout.md
+++ b/microsoft.ui.xaml.controls/textcommandbarflyout.md
@@ -24,6 +24,6 @@ Represents a specialized [CommandBarFlyout](commandbarflyout.md) that contains c
 > For more info, design guidance, and code examples, see [Command bar flyout](/windows/apps/design/controls/command-bar-flyout).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery:/item/CommandBarFlyout).
+> [Open the WinUI 3 Gallery app and see the CommandBarFlyout in action](winui3gallery:/item/CommandBarFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/timepicker.md
+++ b/microsoft.ui.xaml.controls/timepicker.md
@@ -92,7 +92,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Time picker](/windows/apps/design/controls/time-picker).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TimePicker in action](winui3gallery:/item/TimePicker).
+> [Open the WinUI 3 Gallery app and see the TimePicker in action](winui3gallery:/item/TimePicker)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/togglemenuflyoutitem.md
+++ b/microsoft.ui.xaml.controls/togglemenuflyoutitem.md
@@ -35,7 +35,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Menus and context menus](/windows/apps/design/controls/menus).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout).
+> [Open the WinUI 3 Gallery app and see the MenuFlyout in action](winui3gallery:/item/MenuFlyout)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/togglesplitbutton.md
+++ b/microsoft.ui.xaml.controls/togglesplitbutton.md
@@ -30,6 +30,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Buttons](/windows/apps/design/controls/buttons#create-a-split-button).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ToggleSplitButton in action](winui3gallery:/item/ToggleSplitButton).
+> [Open the WinUI 3 Gallery app and see the ToggleSplitButton in action](winui3gallery:/item/ToggleSplitButton)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/toggleswitch.md
+++ b/microsoft.ui.xaml.controls/toggleswitch.md
@@ -45,7 +45,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Toggle switches](/windows/apps/design/controls/toggles).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ToggleSwitch in action](winui3gallery:/item/ToggleSwitch).
+> [Open the WinUI 3 Gallery app and see the ToggleSwitch in action](winui3gallery:/item/ToggleSwitch)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/tooltip.md
+++ b/microsoft.ui.xaml.controls/tooltip.md
@@ -86,7 +86,7 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Tooltips](/windows/apps/design/controls/tooltips).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the Tooltips in action](winui3gallery:/item/Tooltips).
+> [Open the WinUI 3 Gallery app and see the Tooltips in action](winui3gallery:/item/Tooltips)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.controls/treeview.md
+++ b/microsoft.ui.xaml.controls/treeview.md
@@ -30,6 +30,6 @@ XAML also includes resources that you can use to modify the colors of a control 
 > For more info, design guidance, and code examples, see [Tree view](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)

--- a/microsoft.ui.xaml.controls/treeviewcollapsedeventargs.md
+++ b/microsoft.ui.xaml.controls/treeviewcollapsedeventargs.md
@@ -24,6 +24,6 @@ Provides event data for the [TreeView.Collapsed](treeview_collapsed.md) event.
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewdragitemscompletedeventargs.md
+++ b/microsoft.ui.xaml.controls/treeviewdragitemscompletedeventargs.md
@@ -24,6 +24,6 @@ Provides event data for the [TreeView.DragItemsCompleted](treeview_dragitemscomp
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewdragitemsstartingeventargs.md
+++ b/microsoft.ui.xaml.controls/treeviewdragitemsstartingeventargs.md
@@ -24,6 +24,6 @@ Provides event data for the [TreeView.DragItemsStarting](treeview_dragitemsstart
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewexpandingeventargs.md
+++ b/microsoft.ui.xaml.controls/treeviewexpandingeventargs.md
@@ -24,6 +24,6 @@ Provides event data for the [TreeView.Expanding](treeview_expanding.md) event.
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewitem.md
+++ b/microsoft.ui.xaml.controls/treeviewitem.md
@@ -24,6 +24,6 @@ Represents the container for an item in a [TreeView](treeview.md) control.
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewiteminvokedeventargs.md
+++ b/microsoft.ui.xaml.controls/treeviewiteminvokedeventargs.md
@@ -24,6 +24,6 @@ Provides event data for the [TreeView.ItemInvoked](treeview_iteminvoked.md) even
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewlist.md
+++ b/microsoft.ui.xaml.controls/treeviewlist.md
@@ -24,6 +24,6 @@ Represents a flattened list of tree view items so that operations such as keyboa
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewnode.md
+++ b/microsoft.ui.xaml.controls/treeviewnode.md
@@ -24,6 +24,6 @@ Represents a node in a [TreeView](treeview.md) control.
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/treeviewselectionmode.md
+++ b/microsoft.ui.xaml.controls/treeviewselectionmode.md
@@ -38,6 +38,6 @@ The user can select multiple items.
 > For more info, design guidance, and code examples, see [TreeView](/windows/apps/design/controls/tree-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView).
+> [Open the WinUI 3 Gallery app and see the TreeView in action](winui3gallery:/item/TreeView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/twopaneview.md
+++ b/microsoft.ui.xaml.controls/twopaneview.md
@@ -25,6 +25,6 @@ Represents a container with two views that size and position content in the avai
 > For more info, design guidance, and code examples, see [Two pane view](/windows/apps/design/controls/two-pane-view).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the TwoPaneView in action](winui3gallery:/item/TwoPaneView).
+> [Open the WinUI 3 Gallery app and see the TwoPaneView in action](winui3gallery:/item/TwoPaneView)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)

--- a/microsoft.ui.xaml.controls/uniformgridlayout.md
+++ b/microsoft.ui.xaml.controls/uniformgridlayout.md
@@ -27,7 +27,7 @@ UniformGridLayout supports virtualization when attached to a host that supports 
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/uniformgridlayoutitemsjustification.md
+++ b/microsoft.ui.xaml.controls/uniformgridlayoutitemsjustification.md
@@ -53,6 +53,6 @@ This enumeration provides values for the [UniformGridLayout.ItemsJustification](
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/uniformgridlayoutitemsstretch.md
+++ b/microsoft.ui.xaml.controls/uniformgridlayoutitemsstretch.md
@@ -41,6 +41,6 @@ This enumeration provides values for the [UniformGrid.ItemsStretch](uniformgridl
 > For more info, design guidance, and code examples, see [ItemsRepeater](/windows/apps/design/controls/items-repeater).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater).
+> [Open the WinUI 3 Gallery app and see the ItemsRepeater in action](winui3gallery:/item/ItemsRepeater)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.controls/variablesizedwrapgrid.md
+++ b/microsoft.ui.xaml.controls/variablesizedwrapgrid.md
@@ -79,7 +79,7 @@ In order to support XAML processor access to the attached properties, and also t
 > For more info, design guidance, and code examples, see [Layout panels](/windows/apps/design/layout/layout-panels#variablesizedwrapgrid).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the VariableSizedWrapGrid in action](winui3gallery:/item/VariableSizedWrapGrid).
+> [Open the WinUI 3 Gallery app and see the VariableSizedWrapGrid in action](winui3gallery:/item/VariableSizedWrapGrid)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.controls/viewbox.md
+++ b/microsoft.ui.xaml.controls/viewbox.md
@@ -31,7 +31,7 @@ Viewbox is a container control that scales its content to a specified size.
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ViewBox in action](winui3gallery:/item/ViewBox).
+> [Open the WinUI 3 Gallery app and see the ViewBox in action](winui3gallery:/item/ViewBox)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.data/collectionviewsource.md
+++ b/microsoft.ui.xaml.data/collectionviewsource.md
@@ -34,7 +34,7 @@ If the items in the collection are collections themselves, or are objects that c
 > For more info, design guidance, and code examples, see [Semantic zoom](/windows/apps/design/controls/semantic-zoom).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the SemanticZoom in action](winui3gallery:/item/SemanticZoom).
+> [Open the WinUI 3 Gallery app and see the SemanticZoom in action](winui3gallery:/item/SemanticZoom)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.input/standarduicommand.md
+++ b/microsoft.ui.xaml.input/standarduicommand.md
@@ -48,6 +48,6 @@ The platform provides the following set of commands.
 > For more info, design guidance, and code examples, see [Commanding basics](/windows/uwp/layout/commanding-basics).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the StandardUICommand in action](winui3gallery:/item/StandardUICommand).
+> [Open the WinUI 3 Gallery app and see the StandardUICommand in action](winui3gallery:/item/StandardUICommand)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.input/xamluicommand.md
+++ b/microsoft.ui.xaml.input/xamluicommand.md
@@ -40,6 +40,6 @@ There are two ways to process a `Button` command (controls with a `Command` prop
 > For more info, design guidance, and code examples, see  [Commanding basics](/windows/uwp/layout/commanding-basics).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the XamlUICommand in action](winui3gallery:/item/XamlUICommand).
+> [Open the WinUI 3 Gallery app and see the XamlUICommand in action](winui3gallery:/item/XamlUICommand)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.media.animation/connectedanimation.md
+++ b/microsoft.ui.xaml.media.animation/connectedanimation.md
@@ -27,7 +27,7 @@ See the [Connected animation sample](https://github.com/microsoft/WindowsComposi
 > For more info, design guidance, and code examples, see [Connected animation](/windows/apps/design/motion/connected-animation).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see ConnectedAnimation in action](winui3gallery:/item/ConnectedAnimation).
+> [Open the WinUI 3 Gallery app and see ConnectedAnimation in action](winui3gallery:/item/ConnectedAnimation)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.media.animation/connectedanimationservice.md
+++ b/microsoft.ui.xaml.media.animation/connectedanimationservice.md
@@ -25,7 +25,7 @@ See the [Connected animation sample](https://github.com/microsoft/WindowsComposi
 > For more info, design guidance, and code examples, see [Connected animation](/windows/apps/design/motion/connected-animation).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see ConnectedAnimation in action](winui3gallery:/item/ConnectedAnimation).
+> [Open the WinUI 3 Gallery app and see ConnectedAnimation in action](winui3gallery:/item/ConnectedAnimation)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.media.animation/navigationthemetransition.md
+++ b/microsoft.ui.xaml.media.animation/navigationthemetransition.md
@@ -89,7 +89,7 @@ Frame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
 > For more info, design guidance, and code examples, see [Page transitions](/windows/apps/design/motion/page-transitions).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see PageTransitions in action](winui3gallery:/item/PageTransitions).
+> [Open the WinUI 3 Gallery app and see PageTransitions in action](winui3gallery:/item/PageTransitions)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.media/acrylicbrush.md
+++ b/microsoft.ui.xaml.media/acrylicbrush.md
@@ -24,6 +24,6 @@ Paints an area with a semi-transparent material that uses multiple effects inclu
 > For more info, design guidance, and code examples, see [Acrylic material](/windows/apps/design/style/acrylic).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the AcrylicBrush in action](winui3gallery:/item/Acrylic).
+> [Open the WinUI 3 Gallery app and see the AcrylicBrush in action](winui3gallery:/item/Acrylic)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml.media/radialgradientbrush.md
+++ b/microsoft.ui.xaml.media/radialgradientbrush.md
@@ -51,7 +51,7 @@ If you look at the existing control template definitions for Windows Runtime XAM
 > For more info, design guidance, and code examples, see [XAML Brushes](/windows/apps/design/style/brushes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the RadialGradientBrush in action](winui3gallery:/item/RadialGradientBrush).
+> [Open the WinUI 3 Gallery app and see the RadialGradientBrush in action](winui3gallery:/item/RadialGradientBrush)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml.shapes/ellipse.md
+++ b/microsoft.ui.xaml.shapes/ellipse.md
@@ -40,7 +40,7 @@ This example shows how to create an Ellipse in XAML and set some of its common p
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.shapes/line.md
+++ b/microsoft.ui.xaml.shapes/line.md
@@ -57,7 +57,7 @@ This example shows how to use the Line class to create three lines.
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.shapes/microsoft_ui_xaml_shapes.md
+++ b/microsoft.ui.xaml.shapes/microsoft_ui_xaml_shapes.md
@@ -17,7 +17,7 @@ Defines basic shapes that are intended for decorative rendering or for compositi
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.shapes/path.md
+++ b/microsoft.ui.xaml.shapes/path.md
@@ -40,7 +40,7 @@ This XAML example uses a **Path** with a [GeometryGroup](../microsoft.ui.xaml.me
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.shapes/polygon.md
+++ b/microsoft.ui.xaml.shapes/polygon.md
@@ -56,7 +56,7 @@ This example shows how to use a Polygon to create a triangle.
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.shapes/polyline.md
+++ b/microsoft.ui.xaml.shapes/polyline.md
@@ -35,7 +35,7 @@ This example shows how to use a Polyline to create a closed triangle.
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.shapes/rectangle.md
+++ b/microsoft.ui.xaml.shapes/rectangle.md
@@ -36,7 +36,7 @@ This example shows how to create a Rectangle in XAML and set some of its common 
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml.shapes/shape.md
+++ b/microsoft.ui.xaml.shapes/shape.md
@@ -37,7 +37,7 @@ Of these, [Rectangle](rectangle.md), [Path](path.md) and [Ellipse](ellipse.md) a
 > For more info, design guidance, and code examples, see [Draw shapes](/windows/apps/design/controls/shapes).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape).
+> [Open the WinUI 3 Gallery app and see Shape features in action](winui3gallery://item/Shape)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery)
 

--- a/microsoft.ui.xaml/elementsoundplayer.md
+++ b/microsoft.ui.xaml/elementsoundplayer.md
@@ -21,7 +21,7 @@ For more info, see [Sound design guidance](/windows/apps/design/style/sound).
 > For more info, design guidance, and code examples, see [Sound](/windows/apps/design/style/sound).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the ElementSoundPlayer in action](winui3gallery:/item/Sound).
+> [Open the WinUI 3 Gallery app and see the ElementSoundPlayer in action](winui3gallery:/item/Sound)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 

--- a/microsoft.ui.xaml/microsoft_ui_xaml.md
+++ b/microsoft.ui.xaml/microsoft_ui_xaml.md
@@ -20,6 +20,6 @@ Provides general framework APIs for the Windows UI Library (WinUI).
 ## -examples
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see the controls in action](winui3gallery:/item/).
+> [Open the WinUI 3 Gallery app and see the controls in action](winui3gallery:/item/)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).

--- a/microsoft.ui.xaml/uielement_transitions.md
+++ b/microsoft.ui.xaml/uielement_transitions.md
@@ -61,7 +61,7 @@ It's not common to set the value of the `Transitions` property directly on a [UI
 > For more info, design guidance, and code examples, see [Motion](/windows/apps/design/motion/).
 
 > [!div class="nextstepaction"]
-> [Open the WinUI 3 Gallery app and see transitions in action](winui3gallery://category/Motion).
+> [Open the WinUI 3 Gallery app and see transitions in action](winui3gallery://category/Motion)
 
 > The **WinUI 3 Gallery** app includes interactive examples of most WinUI 3 controls, features, and functionality. Get the app from the [Microsoft Store](https://www.microsoft.com/store/productId/9P3JFPWWDZRC) or get the source code on [GitHub](https://github.com/microsoft/WinUI-Gallery).
 


### PR DESCRIPTION
See the image below:

<img width="475" alt="image" src="https://github.com/MicrosoftDocs/winapps-winrt-api/assets/80524586/b4f597a9-bc85-49fb-a190-d5c75bc59be8">