### PR TITLE
controls: Add a missing closing tag for GridView

### DIFF
--- a/microsoft.ui.xaml.controls/gridview.md
+++ b/microsoft.ui.xaml.controls/gridview.md
@@ -160,6 +160,7 @@ Here, a GridView is bound to a grouped [CollectionViewSource](../microsoft.ui.xa
                 </GroupStyle>
             </GridView.GroupStyle>
         </GridView>
+    </Grid>
 </Page>
 ```
 


### PR DESCRIPTION
The Grid closing tag was missing from the code sample in the examples section.