### PR TITLE
Update titlebar paddings

### DIFF
--- a/microsoft.ui.xaml/window_settitlebar_1494775390.md
+++ b/microsoft.ui.xaml/window_settitlebar_1494775390.md
@@ -60,12 +60,12 @@ This example shows how to extend the window's content area and replace the syste
             <Image Source="Images/WindowIcon.png"
                    HorizontalAlignment="Left" 
                    Width="16" Height="16" 
-                   Margin="8,0"/>
+                   Margin="16,0"/>
             <TextBlock x:Name="AppTitleTextBlock" Text="App title"
                        TextWrapping="NoWrap"
                        Style="{StaticResource CaptionTextBlockStyle}" 
                        VerticalAlignment="Center"
-                       Margin="28,0,0,0"/>
+                       Margin="40,0,0,0"/>
         </Grid>
 
         <NavigationView Grid.Row="1">

--- a/microsoft.ui.xaml/window_settitlebar_1494775390.md
+++ b/microsoft.ui.xaml/window_settitlebar_1494775390.md
@@ -65,7 +65,7 @@ This example shows how to extend the window's content area and replace the syste
                        TextWrapping="NoWrap"
                        Style="{StaticResource CaptionTextBlockStyle}" 
                        VerticalAlignment="Center"
-                       Margin="40,0,0,0"/>
+                       Margin="48,0,0,0"/>
         </Grid>
 
         <NavigationView Grid.Row="1">


### PR DESCRIPTION
The current sample uses the wrong spacing.

It should be:

16px - app icon - 16px - app title (according to the design specs)


![image](https://github.com/MicrosoftDocs/winapps-winrt-api/assets/9866362/ea68f000-94e1-47ed-bda6-e4f3f7157ba1)

