### PR TITLE
Update dispatcherqueue_getforcurrentthread_1771949562.md

### DIFF
--- a/microsoft.ui.dispatching/dispatcherqueue_getforcurrentthread_1771949562.md
+++ b/microsoft.ui.dispatching/dispatcherqueue_getforcurrentthread_1771949562.md
@@ -15,7 +15,7 @@ Gets the [DispatcherQueue](dispatcherqueue.md) associated with the current threa
 
 ## -returns
 
-A DispatcherQueue instance that will execute tasks serially on the current thread.
+A DispatcherQueue instance that will execute tasks serially on the current thread, or null if no such DispatcherQueue exists.
 
 ## -remarks
 


### PR DESCRIPTION
This API matches the behavior of https://learn.microsoft.com/en-us/uwp/api/windows.system.dispatcherqueue.getforcurrentthread?view=winrt-22621#windows-system-dispatcherqueue-getforcurrentthread when no DispatcherQueue exists. Without this caveat, the documentation is confusing.