### PR TITLE
Update desktopwindowxamlsource_initialize: Fix incorrect reference

### DIFF
--- a/microsoft.ui.xaml.hosting/desktopwindowxamlsource_initialize_1448610474.md
+++ b/microsoft.ui.xaml.hosting/desktopwindowxamlsource_initialize_1448610474.md
@@ -17,7 +17,7 @@ Initializes a new instance of the [DesktopWindowXamlSource](desktopwindowxamlsou
 
 ### -param parentWindowId
 
-The *WindowId* of the HWND (retrieved through [Microsoft.UI.Input.InputNonClientPointerSource.GetForWindowId(Microsoft.UI.WindowId)](../microsoft.ui.input/inputnonclientpointersource_getforwindowid_240994741.md)) of your Win32 application.
+The *WindowId* of the HWND (retrieved through [Win32Interop.GetWindowIdFromWindow(IntPtr)](https://learn.microsoft.com/en-us/windows/apps/api-reference/cs-interop-apis/microsoft.ui/microsoft.ui.win32interop.getwindowidfromwindow)) of your Win32 application.
 
 ## -remarks
 

--- a/microsoft.ui.xaml.hosting/desktopwindowxamlsource_initialize_1448610474.md
+++ b/microsoft.ui.xaml.hosting/desktopwindowxamlsource_initialize_1448610474.md
@@ -17,7 +17,7 @@ Initializes a new instance of the [DesktopWindowXamlSource](desktopwindowxamlsou
 
 ### -param parentWindowId
 
-The *WindowId* of the HWND (retrieved through [Win32Interop.GetWindowIdFromWindow(IntPtr)](https://learn.microsoft.com/en-us/windows/apps/api-reference/cs-interop-apis/microsoft.ui/microsoft.ui.win32interop.getwindowidfromwindow)) of your Win32 application.
+The *WindowId* of the HWND (retrieved through [Win32Interop.GetWindowIdFromWindow(IntPtr)](/windows/apps/api-reference/cs-interop-apis/microsoft.ui/microsoft.ui.win32interop.getwindowidfromwindow) of your Win32 application.
 
 ## -remarks
 


### PR DESCRIPTION
The currently referenced API doesn't give you a WindowId from a hWnd.

(sorry, I don't know how to do cross-repo links)