### PR TITLE
Correction on minor typo ILaunchActivatedEventArge -> ILaunchActivatedEventArgs

### DIFF
--- a/microsoft.windows.applifecycle/appactivationarguments_data.md
+++ b/microsoft.windows.applifecycle/appactivationarguments_data.md
@@ -23,7 +23,7 @@ The value of this property has one of the following data types, depending on the
 
 | Activation kind | Data type |
 |-----------------|-----------------------|
-| `Launch` | [ILaunchActivatedEventArge](/uwp/api/windows.applicationmodel.activation.ilaunchactivatedeventargs) |
+| `Launch` | [ILaunchActivatedEventArgs](/uwp/api/windows.applicationmodel.activation.ilaunchactivatedeventargs) |
 | `File` | [IFileActivatedEventArgs](/uwp/api/windows.applicationmodel.activation.ifileactivatedeventargs) |
 | `Protocol` | [IProtocolActivatedEventArgs](/uwp/api/windows.applicationmodel.activation.iprotocolactivatedeventargs) |
 | `StartupTask` | [IStartupTaskActivatedEventArgs](/uwp/api/windows.applicationmodel.activation.istartuptaskactivatedeventargs) |


### PR DESCRIPTION
I noticed one simple typo on winrt api documentation and here's the PR to correct it.
The original text is ILaunchActivatedEventArge, which should be ILaunchActivatedEventArgs (confirmed by the link it points to)