### PR TITLE
Update the PushNotifications remarks about registering the handler before calling Register() to include the thrown runtime exception

### DIFF
--- a/microsoft.windows.pushnotifications/pushnotificationmanager_pushreceived.md
+++ b/microsoft.windows.pushnotifications/pushnotificationmanager_pushreceived.md
@@ -18,7 +18,8 @@ Raised when a push notification for the app is received by the platform.
 
 ## -remarks
 
-To ensure that the **PushReceived** event handler is called within the process of the running app, be sure to register the handler for this event before calling [Register](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.Register). Otherwise, a new process will be launched to handle the notification.
+To ensure that the **PushReceived** event handler is called within the process of the running app, be sure to register the handler for this event before calling [Register](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.Register). Otherwise, the following runtime exception will be thrown:
+> System.Runtime.InteropServices.COMException: 'Element not found. Must register event handlers before calling Register().'
 
 ## -see-also
 

--- a/microsoft.windows.pushnotifications/pushnotificationmanager_register_292201929.md
+++ b/microsoft.windows.pushnotifications/pushnotificationmanager_register_292201929.md
@@ -20,7 +20,8 @@ Registers the app to receive [PushReceived](xref:Microsoft.Windows.PushNotificat
 
 For packaged apps, the COM server is defined in the app manifest. The process calling **Register** and the process defined in the manifest as the COM server are required to be the same. For unpackaged apps, the calling process will be registered as the COM server.
 
-To ensure that the **PushReceived** event handler is called within the process of the running app, be sure to register the handler for that event before calling **Register**. Otherwise, a new process will be launched to handle the notification.
+To ensure that the **PushReceived** event handler is called within the process of the running app, be sure to register the handler for that event before calling **Register**. Otherwise, the following runtime exception will be thrown:
+> System.Runtime.InteropServices.COMException: 'Element not found. Must register event handlers before calling Register().'
 
 Before your app terminates, call [Unregister](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.Unregister) or [UnregisterAll](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.UnregisterAll).
 

--- a/microsoft.windows.pushnotifications/pushnotificationmanager_register_292201929.md
+++ b/microsoft.windows.pushnotifications/pushnotificationmanager_register_292201929.md
@@ -20,7 +20,7 @@ Registers the app to receive [PushReceived](xref:Microsoft.Windows.PushNotificat
 
 For packaged apps, the COM server is defined in the app manifest. The process calling **Register** and the process defined in the manifest as the COM server are required to be the same. For unpackaged apps, the calling process will be registered as the COM server.
 
-To ensure that the **PushReceived** event handler is called within the process of the running app, be sure to register the handler for that event before calling **Register**. Otherwise, the following runtime exception will be thrown:
+To ensure that the [PushReceived](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.PushReceived) event handler is called within the process of the running app, be sure to register the handler for that event before calling **Register**. Otherwise, the following runtime exception will be thrown:
 > System.Runtime.InteropServices.COMException: 'Element not found. Must register event handlers before calling Register().'
 
 Before your app terminates, call [Unregister](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.Unregister) or [UnregisterAll](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.UnregisterAll).

--- a/microsoft.windows.pushnotifications/pushnotificationreceivedeventargs.md
+++ b/microsoft.windows.pushnotifications/pushnotificationreceivedeventargs.md
@@ -16,7 +16,8 @@ Provides data for the [PushReceived](xref:Microsoft.Windows.PushNotifications.Pu
 
 ## -remarks
 
-To ensure that the **PushReceived** event handler is called within the process of the running app, be sure to register the handler for this event before calling [Register](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.Register). Otherwise, a new process will be launched to handle the notification.
+To ensure that the [PushReceived](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.PushReceived) event handler is called within the process of the running app, be sure to register the handler for this event before calling [Register](xref:Microsoft.Windows.PushNotifications.PushNotificationManager.Register). Otherwise, the following runtime exception will be thrown:
+> System.Runtime.InteropServices.COMException: 'Element not found. Must register event handlers before calling Register().'
 
 
 ## -see-also


### PR DESCRIPTION
Resolves [#2395 in the WindowsAppSDK repository](https://github.com/microsoft/WindowsAppSDK/issues/2395)

## Before:
* The remarks related to Microsoft.Windows.PushNotifications ([see this example](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.windows.pushnotifications.pushnotificationmanager.pushreceived?view=windows-app-sdk-1.7#remarks)) warned against registering the PushNotificationsManager before registering the PushReceived event handlers, but didn't specify that a runtime exception would be thrown.

## After:
* The remarks include the COMException that is thrown when a PushNotificationsManager is registered before the PushReceived event handler.