### PR TITLE
Update ContentCoordinateRoundingMode.Auto description

### DIFF
--- a/microsoft.ui.content/contentcoordinateroundingmode.md
+++ b/microsoft.ui.content/contentcoordinateroundingmode.md
@@ -17,7 +17,7 @@ Specifies the rounding methods used for converting screen coordinates (float to 
 
 ### -field Auto: 0
 
-Use the current floating-point unit (FPU) setting. Default.
+Rounds towards zero by discarding the fractional portion of the floating point number. Default.
 
 ### -field Floor: 1
 


### PR DESCRIPTION
The previous description has never been the actual behavior of the API. This new description correctly describes the rounding behavior as rounding towards zero (truncating).

I'm not entirely certain of the correct process here, since this isn't a doc change for a specific WinAppSDK version, but should be updated on all WinAppSDK versions of this page.

Very happy for any edits or improvements as you all see fit.