### PR TITLE
Update remarks on taskbar icon precedence

### DIFF
--- a/microsoft.ui.windowing/appwindow_settaskbaricon_313007636.md
+++ b/microsoft.ui.windowing/appwindow_settaskbaricon_313007636.md
@@ -23,6 +23,8 @@ The path of the icon.
 
 For more information about setting the icon, see [SetIcon](appwindow_seticon_348408788.md). This method works the same way, but lets you set the taskbar icon independently of the title bar icon.
 
+Icons from existing shell links and [System.AppUserModel.RelaunchIconResource](/windows/win32/properties/props-system-appusermodel-relaunchiconresource) take precedence. In these cases, this method cannot change the taskbar icon.
+
 ## -see-also
 
 [SetIcon](appwindow_seticon_348408788.md), [SetTitleBarIcon](appwindow_settitlebaricon_1410311439.md)


### PR DESCRIPTION
Clarified that existing shell link icons and RelaunchIconResource take precedence over this method.