### PR TITLE
Correct the fileName parmeter description for WASDK ResourceLoader(String fileName) constructor

### DIFF
--- a/microsoft.applicationmodel.resources/resourceloader_resourceloader_290278668.md
+++ b/microsoft.applicationmodel.resources/resourceloader_resourceloader_290278668.md
@@ -19,12 +19,9 @@ Constructs a new [ResourceLoader](resourceloader.md) object for the specified [R
 
 The path and name of the file that should be used for the current context.
 
-> [!NOTE]
-> The resource identifier is treated as a Uniform Resource Identifier (URI) fragment, subject to Uniform Resource Identifier (URI) semantics. For example, "Caption%20" is treated as "Caption ". Do not use "?" or "#" in resource identifiers, as they terminate the resource path. For example, "Foo?3" is treated as "Foo".
-
 ## -remarks
 
-This constructor is typically used to access resources relative to a resource file with the specified resource identifier. For example, `new ResourceLoader('Errors');` is relative to errors.resjson or errors.resw.
+This constructor is typically used to load resources from a specific PRI file. For example, `new ResourceLoader("MyResources.pri")` loads from the specified file relative to the app's working directory.
 
 ## -examples
 

--- a/microsoft.applicationmodel.resources/resourceloader_resourceloader_290278668.md
+++ b/microsoft.applicationmodel.resources/resourceloader_resourceloader_290278668.md
@@ -17,7 +17,7 @@ Constructs a new [ResourceLoader](resourceloader.md) object for the specified [R
 
 ### -param fileName
 
-The resource identifier of the [ResourceMap](resourcemap.md) that the new resource loader uses for unqualified resource references. It can then retrieve resources relative to those references.
+The path and name of the file that should be used for the current context.
 
 > [!NOTE]
 > The resource identifier is treated as a Uniform Resource Identifier (URI) fragment, subject to Uniform Resource Identifier (URI) semantics. For example, "Caption%20" is treated as "Caption ". Do not use "?" or "#" in resource identifiers, as they terminate the resource path. For example, "Foo?3" is treated as "Foo".

--- a/microsoft.windows.applicationmodel.resources/resourceloader_resourceloader_290278668.md
+++ b/microsoft.windows.applicationmodel.resources/resourceloader_resourceloader_290278668.md
@@ -20,12 +20,9 @@ Constructs a new [ResourceLoader](resourceloader.md) object for the specified [R
 
 The path and name of the file that should be used for the current context.
 
-> [!NOTE]
-> The resource identifier is treated as a Uniform Resource Identifier (URI) fragment, subject to Uniform Resource Identifier (URI) semantics. For example, "Caption%20" is treated as "Caption ". Do not use "?" or "#" in resource identifiers, as they terminate the resource path. For example, "Foo?3" is treated as "Foo".
-
 ## -remarks
 
-This constructor is typically used to access resources relative to a resource file with the specified resource identifier. For example, `new ResourceLoader('Errors');` is relative to errors.resjson or errors.resw.
+This constructor is typically used to load resources from a specific PRI file. For example, `new ResourceLoader("MyResources.pri")` loads from the specified file relative to the app's working directory.
 
 ## -see-also
 

--- a/microsoft.windows.applicationmodel.resources/resourceloader_resourceloader_290278668.md
+++ b/microsoft.windows.applicationmodel.resources/resourceloader_resourceloader_290278668.md
@@ -18,7 +18,7 @@ Constructs a new [ResourceLoader](resourceloader.md) object for the specified [R
 
 ### -param fileName
 
-The resource identifier of the [ResourceMap](resourcemap.md) that the new resource loader uses for unqualified resource references. It can then retrieve resources relative to those references.
+The path and name of the file that should be used for the current context.
 
 > [!NOTE]
 > The resource identifier is treated as a Uniform Resource Identifier (URI) fragment, subject to Uniform Resource Identifier (URI) semantics. For example, "Caption%20" is treated as "Caption ". Do not use "?" or "#" in resource identifiers, as they terminate the resource path. For example, "Foo?3" is treated as "Foo".


### PR DESCRIPTION
This PR updates the description for the `fileName` parameter required for Windows App SDK's ResourceLoader.String() constructor. The `fileName` parameter takes in the path to a `.pri` file, not a `resourceMap`. The description added matches the description for the same parameter in [ResourceLoader(String, String)](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.windows.applicationmodel.resources.resourceloader.-ctor?view=windows-app-sdk-1.0#microsoft-windows-applicationmodel-resources-resourceloader-ctor(system-string-system-string)), which was introduced at the same time as the one-parameter constructor.

See [Windows App SDK Issue #2406 - ResourceLoader can not load the specified resource](https://github.com/microsoft/WindowsAppSDK/issues/2406).