### PR TITLE
Add remarks and examples to Microsoft.Windows.System.Power API docs

### DIFF
--- a/microsoft.windows.system.power/batterystatus.md
+++ b/microsoft.windows.system.power/batterystatus.md
@@ -34,7 +34,7 @@ The battery is charging.
 
 ## -remarks
 
-Use this enum with the [BatteryStatus](powermanager_batterystatus.md) property to determine the current battery state. A value of `NotPresent` indicates a desktop or device without a battery. The `Idle` state typically means the battery is fully charged and connected to AC power.
+Use this enum with the [BatteryStatus](powermanager_batterystatus.md) property to determine the current battery state. A value of `NotPresent` indicates a desktop or device without a battery. The `Idle` state means the battery is neither charging nor discharging.
 
 ## -see-also
 

--- a/microsoft.windows.system.power/batterystatus.md
+++ b/microsoft.windows.system.power/batterystatus.md
@@ -34,6 +34,8 @@ The battery is charging.
 
 ## -remarks
 
+Use this enum with the [BatteryStatus](powermanager_batterystatus.md) property to determine the current battery state. A value of `NotPresent` indicates a desktop or device without a battery. The `Idle` state typically means the battery is fully charged and connected to AC power.
+
 ## -see-also
 
 [BatteryStatus property](powermanager_batterystatus.md), [BatteryStatusChanged event](powermanager_batterystatuschanged.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/effectivepowermode.md
+++ b/microsoft.windows.system.power/effectivepowermode.md
@@ -46,6 +46,10 @@ The device is in the windows mixed reality power mode.
 
 ## -remarks
 
+The effective power mode reflects the combined result of the user's power plan selection, battery saver state, and other system policies. The values are ordered from lowest power consumption (`BatterySaver`) to highest (`MaxPerformance`), with `GameMode` and `MixedReality` representing specialized modes for those workloads.
+
+Use this enum with the [EffectivePowerMode](powermanager_effectivepowermode.md) or [EffectivePowerMode2](powermanager_effectivepowermode2.md) property to adapt your app's behavior to the current power mode.
+
 ## -see-also
 
 [EffectivePowerMode property](powermanager_effectivepowermode.md), [EffectivePowerModeChanged event](powermanager_effectivepowermodechanged.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/effectivepowermode.md
+++ b/microsoft.windows.system.power/effectivepowermode.md
@@ -46,7 +46,7 @@ The device is in the windows mixed reality power mode.
 
 ## -remarks
 
-The effective power mode reflects the combined result of the user's power plan selection, battery saver state, and other system policies. The values are ordered from lowest power consumption (`BatterySaver`) to highest (`MaxPerformance`), with `GameMode` and `MixedReality` representing specialized modes for those workloads.
+The effective power mode reflects the combined result of the user's power plan selection, battery saver state, and other system policies. `GameMode` and `MixedReality` represent specialized modes for those workloads.
 
 Use this enum with the [EffectivePowerMode](powermanager_effectivepowermode.md) or [EffectivePowerMode2](powermanager_effectivepowermode2.md) property to adapt your app's behavior to the current power mode.
 

--- a/microsoft.windows.system.power/microsoft_windows_system_power.md
+++ b/microsoft.windows.system.power/microsoft_windows_system_power.md
@@ -13,7 +13,7 @@ For more information, see [Power management with the app lifecycle API](/windows
 
 ## -remarks
 
-The **Microsoft.Windows.System.Power** namespace is part of the Windows App SDK and works in both packaged and unpackaged desktop apps. All members are on the static [PowerManager](powermanager.md) class — read properties to query the current power state, and subscribe to events to react when the state changes.
+The **Microsoft.Windows.System.Power** namespace is part of the Windows App SDK. The [PowerManager](powermanager.md) class provides static properties to query the current power state and static events to react when the state changes. The namespace also defines enums such as [BatteryStatus](batterystatus.md), [EffectivePowerMode](effectivepowermode.md), and [PowerSourceKind](powersourcekind.md) that represent the possible values for those properties.
 
 Common scenarios include deferring background work when the device is on battery, reducing visual effects in power-saver mode, and pausing activity when the user is away or the display is off.
 

--- a/microsoft.windows.system.power/microsoft_windows_system_power.md
+++ b/microsoft.windows.system.power/microsoft_windows_system_power.md
@@ -13,6 +13,10 @@ For more information, see [Power management with the app lifecycle API](/windows
 
 ## -remarks
 
+The **Microsoft.Windows.System.Power** namespace is part of the Windows App SDK and works in both packaged and unpackaged desktop apps. All members are on the static [PowerManager](powermanager.md) class — read properties to query the current power state, and subscribe to events to react when the state changes.
+
+Common scenarios include deferring background work when the device is on battery, reducing visual effects in power-saver mode, and pausing activity when the user is away or the display is off.
+
 ## -see-also
 
 [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/powermanager.md
+++ b/microsoft.windows.system.power/powermanager.md
@@ -18,7 +18,7 @@ Provides static events that notify your app of changes to the devices power stat
 
 **PowerManager** is a static class — you do not instantiate it. Read its properties to query the current power state and subscribe to its events to be notified when the state changes.
 
-All properties and events are available in both packaged and unpackaged Windows App SDK desktop apps. The class wraps the underlying Win32 [power setting GUIDs](/windows/win32/power/power-setting-guids) into a strongly-typed WinRT surface.
+The class wraps the underlying Win32 [power setting GUIDs](/windows/win32/power/power-setting-guids) into a strongly-typed WinRT surface.
 
 For more information, see [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power).
 

--- a/microsoft.windows.system.power/powermanager.md
+++ b/microsoft.windows.system.power/powermanager.md
@@ -16,7 +16,11 @@ Provides static events that notify your app of changes to the devices power stat
 
 ## -remarks
 
-For more information about using this class, see [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power).
+**PowerManager** is a static class — you do not instantiate it. Read its properties to query the current power state and subscribe to its events to be notified when the state changes.
+
+All properties and events are available in both packaged and unpackaged Windows App SDK desktop apps. The class wraps the underlying Win32 [power setting GUIDs](/windows/win32/power/power-setting-guids) into a strongly-typed WinRT surface.
+
+For more information, see [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power).
 
 ## -see-also
 
@@ -24,4 +28,35 @@ For more information about using this class, see [Power management with the app 
 
 ## -examples
 
-For code examples that demonstrsate how to use this class, see [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power).
+The following example checks whether the device is on battery and subscribes to power-state change events.
+
+```csharp
+using Microsoft.Windows.System.Power;
+
+// Check current power source
+if (PowerManager.PowerSourceKind == PowerSourceKind.DC)
+{
+    // Running on battery — defer non-essential work
+    int chargePercent = PowerManager.RemainingChargePercent;
+    System.Diagnostics.Debug.WriteLine($"On battery: {chargePercent}% remaining");
+}
+
+// React to battery status changes
+PowerManager.BatteryStatusChanged += (sender, args) =>
+{
+    BatteryStatus status = PowerManager.BatteryStatus;
+    if (status == BatteryStatus.Discharging)
+    {
+        // Reduce background activity
+    }
+};
+
+// React to energy saver (battery saver) changes
+PowerManager.EnergySaverStatusChanged += (sender, args) =>
+{
+    if (PowerManager.EnergySaverStatus == EnergySaverStatus.On)
+    {
+        // Minimize resource usage
+    }
+};
+```

--- a/microsoft.windows.system.power/powermanager.md
+++ b/microsoft.windows.system.power/powermanager.md
@@ -18,7 +18,7 @@ Provides static events that notify your app of changes to the devices power stat
 
 **PowerManager** is a static class — you do not instantiate it. Read its properties to query the current power state and subscribe to its events to be notified when the state changes.
 
-The class wraps the underlying Win32 [power setting GUIDs](/windows/win32/power/power-setting-guids) into a strongly-typed WinRT surface.
+Several of the properties and enums in this class correspond to Win32 [power setting GUIDs](/windows/win32/power/power-setting-guids), as noted in their individual remarks.
 
 For more information, see [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power).
 

--- a/microsoft.windows.system.power/powermanager_batterystatus.md
+++ b/microsoft.windows.system.power/powermanager_batterystatus.md
@@ -20,6 +20,8 @@ The current status of the battery.
 
 ## -remarks
 
+Use this property to determine whether the device has a battery and whether it is currently charging, discharging, or idle. Subscribe to the [BatteryStatusChanged](powermanager_batterystatuschanged.md) event to be notified when this value changes.
+
 ## -see-also
 
 [BatteryStatusChanged event](powermanager_batterystatuschanged.md), [BatteryStatus enum](batterystatus.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/powermanager_effectivepowermode.md
+++ b/microsoft.windows.system.power/powermanager_effectivepowermode.md
@@ -19,6 +19,10 @@ The current effective power mode of the device.
 
 ## -remarks
 
+This property returns an asynchronous operation that resolves to the current [EffectivePowerMode](effectivepowermode.md). For a synchronous alternative, use [EffectivePowerMode2](powermanager_effectivepowermode2.md).
+
+The effective power mode reflects the combined result of the user's power plan selection, battery saver state, and system policies. Use this value to adjust your app's resource usage — for example, reduce animation quality or defer background processing when the mode is [BatterySaver](effectivepowermode.md) or [BetterBattery](effectivepowermode.md).
+
 ## -see-also
 
 [EffectivePowerModeChanged event](powermanager_effectivepowermodechanged.md), [EffectivePowerMode enum](effectivepowermode.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power), [EffectivePowerMode2](./powermanager_effectivepowermode2.md)

--- a/microsoft.windows.system.power/powermanager_effectivepowermode.md
+++ b/microsoft.windows.system.power/powermanager_effectivepowermode.md
@@ -21,7 +21,7 @@ The current effective power mode of the device.
 
 This property returns an asynchronous operation that resolves to the current [EffectivePowerMode](effectivepowermode.md). For a synchronous alternative, use [EffectivePowerMode2](powermanager_effectivepowermode2.md).
 
-The effective power mode reflects the combined result of the user's power plan selection, battery saver state, and system policies. Use this value to adjust your app's resource usage — for example, reduce animation quality or defer background processing when the mode is [BatterySaver](effectivepowermode.md) or [BetterBattery](effectivepowermode.md).
+The effective power mode reflects the combined result of the user's power plan selection, battery saver state, and system policies. Use this value to adjust your app's resource usage — for example, reduce animation quality or defer background processing when the mode is `BatterySaver` or `BetterBattery`.
 
 ## -see-also
 

--- a/microsoft.windows.system.power/powermanager_effectivepowermode2.md
+++ b/microsoft.windows.system.power/powermanager_effectivepowermode2.md
@@ -19,7 +19,7 @@ The current effective power mode of the device.
 
 ## -remarks
 
-This property returns the current [EffectivePowerMode](effectivepowermode.md) synchronously. It is equivalent to [EffectivePowerMode](powermanager_effectivepowermode.md), but does not require awaiting an asynchronous operation.
+This property returns the current [EffectivePowerMode](effectivepowermode.md) synchronously. It returns the same value as awaiting [EffectivePowerMode](powermanager_effectivepowermode.md), but does not require an asynchronous call.
 
 Subscribe to the [EffectivePowerModeChanged](powermanager_effectivepowermodechanged.md) event to be notified when this value changes.
 

--- a/microsoft.windows.system.power/powermanager_effectivepowermode2.md
+++ b/microsoft.windows.system.power/powermanager_effectivepowermode2.md
@@ -19,6 +19,10 @@ The current effective power mode of the device.
 
 ## -remarks
 
+This property returns the current [EffectivePowerMode](effectivepowermode.md) synchronously. It is equivalent to [EffectivePowerMode](powermanager_effectivepowermode.md), but does not require awaiting an asynchronous operation.
+
+Subscribe to the [EffectivePowerModeChanged](powermanager_effectivepowermodechanged.md) event to be notified when this value changes.
+
 ## -see-also
 
 [EffectivePowerModeChanged event](powermanager_effectivepowermodechanged.md), [EffectivePowerMode enum](effectivepowermode.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power), [EffectivePowerMode](./powermanager_effectivepowermode.md)

--- a/microsoft.windows.system.power/powermanager_powersupplystatus.md
+++ b/microsoft.windows.system.power/powermanager_powersupplystatus.md
@@ -20,7 +20,7 @@ The current power supply status of the device.
 
 ## -remarks
 
-Use this property to determine whether the power supply is connected and providing adequate power. A value of [Inadequate](powersupplystatus.md) indicates the charger is connected but not supplying enough power to charge the battery (for example, a low-wattage USB charger on a high-power laptop). Subscribe to the [PowerSupplyStatusChanged](powermanager_powersupplystatuschanged.md) event to be notified when this value changes.
+Use this property to determine whether the power supply is connected and providing adequate power. Subscribe to the [PowerSupplyStatusChanged](powermanager_powersupplystatuschanged.md) event to be notified when this value changes.
 
 ## -see-also
 

--- a/microsoft.windows.system.power/powermanager_powersupplystatus.md
+++ b/microsoft.windows.system.power/powermanager_powersupplystatus.md
@@ -20,6 +20,8 @@ The current power supply status of the device.
 
 ## -remarks
 
+Use this property to determine whether the power supply is connected and providing adequate power. A value of [Inadequate](powersupplystatus.md) indicates the charger is connected but not supplying enough power to charge the battery (for example, a low-wattage USB charger on a high-power laptop). Subscribe to the [PowerSupplyStatusChanged](powermanager_powersupplystatuschanged.md) event to be notified when this value changes.
+
 ## -see-also
 
 [PowerSupplyStatusChanged event](powermanager_powersupplystatuschanged.md), [PowerSupplyStatus enum](powersupplystatus.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/powermanager_remainingdischargetime.md
+++ b/microsoft.windows.system.power/powermanager_remainingdischargetime.md
@@ -20,6 +20,8 @@ The remaining discharge time of the battery.
 
 ## -remarks
 
+Returns a [TimeSpan](/dotnet/api/system.timespan) representing the estimated time remaining before the battery is fully discharged. This value is meaningful only when the device is running on battery power ([PowerSourceKind](powermanager_powersourcekind.md) is `DC`). Subscribe to the [RemainingDischargeTimeChanged](powermanager_remainingdischargetimechanged.md) event to be notified when this estimate changes.
+
 ## -see-also
 
 [RemainingDischargeTimeChanged event](powermanager_remainingdischargetimechanged.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/powermanager_systemsuspendstatus.md
+++ b/microsoft.windows.system.power/powermanager_systemsuspendstatus.md
@@ -20,6 +20,8 @@ The current suspend status of the device.
 
 ## -remarks
 
+Use this property to detect when the system is entering or resuming from a suspend (sleep/hibernate) state. Your app can use the [SystemSuspendStatusChanged](powermanager_systemsuspendstatuschanged.md) event together with this property to save state before suspend and refresh data after resume.
+
 ## -see-also
 
 [SystemSuspendStatusChanged event](powermanager_systemsuspendstatuschanged.md), [SystemSuspendStatus enum](systemsuspendstatus.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/powersupplystatus.md
+++ b/microsoft.windows.system.power/powersupplystatus.md
@@ -30,6 +30,8 @@ Power supply is adequate.
 
 ## -remarks
 
+Use this enum with the [PowerSupplyStatus](powermanager_powersupplystatus.md) property. An `Inadequate` supply means the charger is connected but is not providing enough power to maintain or charge the battery — for example, a low-wattage USB charger on a high-power device.
+
 ## -see-also
 
 [PowerSupplyStatus property](powermanager_powersupplystatus.md), [PowerSupplyStatusChanged event](powermanager_powersupplystatuschanged.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/powersupplystatus.md
+++ b/microsoft.windows.system.power/powersupplystatus.md
@@ -30,7 +30,7 @@ Power supply is adequate.
 
 ## -remarks
 
-Use this enum with the [PowerSupplyStatus](powermanager_powersupplystatus.md) property. An `Inadequate` supply means the charger is connected but is not providing enough power to maintain or charge the battery — for example, a low-wattage USB charger on a high-power device.
+Use this enum with the [PowerSupplyStatus](powermanager_powersupplystatus.md) property. `NotPresent` means no power supply is connected, `Inadequate` means a power supply is connected but not providing adequate power, and `Adequate` means the power supply is connected and providing adequate power.
 
 ## -see-also
 

--- a/microsoft.windows.system.power/systemsuspendstatus.md
+++ b/microsoft.windows.system.power/systemsuspendstatus.md
@@ -34,6 +34,8 @@ The user has manually resumed the device from suspend state.
 
 ## -remarks
 
+Use this enum with the [SystemSuspendStatus](powermanager_systemsuspendstatus.md) property and the [SystemSuspendStatusChanged](powermanager_systemsuspendstatuschanged.md) event to detect when the system is entering or leaving a suspend state. The `AutoResume` and `ManualResume` values distinguish between the system waking on its own (for example, due to a scheduled task or network event) and the user explicitly waking the device.
+
 ## -see-also
 
 [SystemSuspendStatus property](powermanager_systemsuspendstatus.md), [SystemSuspendStatusChanged event](powermanager_systemsuspendstatuschanged.md), [Power management with the app lifecycle API](/windows/apps/windows-app-sdk/applifecycle/applifecycle-power)

--- a/microsoft.windows.system.power/systemsuspendstatus.md
+++ b/microsoft.windows.system.power/systemsuspendstatus.md
@@ -34,7 +34,7 @@ The user has manually resumed the device from suspend state.
 
 ## -remarks
 
-Use this enum with the [SystemSuspendStatus](powermanager_systemsuspendstatus.md) property and the [SystemSuspendStatusChanged](powermanager_systemsuspendstatuschanged.md) event to detect when the system is entering or leaving a suspend state. The `AutoResume` and `ManualResume` values distinguish between the system waking on its own (for example, due to a scheduled task or network event) and the user explicitly waking the device.
+Use this enum with the [SystemSuspendStatus](powermanager_systemsuspendstatus.md) property and the [SystemSuspendStatusChanged](powermanager_systemsuspendstatuschanged.md) event to detect when the system is entering or leaving a suspend state. `AutoResume` indicates the system resumed without user interaction, while `ManualResume` indicates the user explicitly woke the device.
 
 ## -see-also
 


### PR DESCRIPTION
## Questions for SME reviewers

The following questions came up during authoring. Accurate answers would directly improve the docs — and are especially important for AI coding assistants (e.g. GitHub Copilot) that use API reference to generate code.

### PowerManager properties

1. **RemainingDischargeTime when on AC** — What does `RemainingDischargeTime` return when the device is plugged in? `TimeSpan.Zero`? `TimeSpan.MaxValue`? Should we document the behavior?
2. **RemainingChargePercent on desktop** — What does `RemainingChargePercent` return on a desktop PC with no battery? 0? -1? Should we document the no-battery case?
3. **PowerSupplyStatus.Inadequate threshold** — Is there a documented wattage or percentage threshold that distinguishes Inadequate from Adequate, or is this OEM-defined?
4. **EffectivePowerMode vs EffectivePowerMode2** — Why do both exist? Is `EffectivePowerMode` (async) deprecated in favor of `EffectivePowerMode2` (sync)? Should we guide developers toward one?

### Events

5. **Event thread/context** — Are PowerManager events raised on the UI thread, a background thread, or the thread that subscribed? This affects whether developers need to marshal to the UI thread.
6. **SystemIdleStatusChanged** — The existing remark says "Raised when the system is busy," which seems backwards. Is this raised when the system transitions to idle, from idle, or both?
7. **Event unsubscription** — Do apps need to explicitly unsubscribe from PowerManager events on shutdown, or does the static event handler handle cleanup?

### Enums

8. **BatteryStatus.Idle vs Charging** — Is `Idle` specifically "fully charged and on AC" or can it also mean "on battery but not discharging" (e.g., conservation mode)?
9. **EffectivePowerMode ordering** — We described the values as ordered from lowest to highest power. Is this ordering guaranteed/contractual, or just the current layout?
10. **SystemSuspendStatus.AutoResume triggers** — What specific conditions cause `AutoResume` vs `ManualResume`? Wake timers? Network wake? Power button?

### General

11. **Win32 parity** — Are there any behavioral differences between these WinRT APIs and the underlying Win32 power setting GUIDs they wrap?
12. **Packaged vs unpackaged** — Are there any capabilities or restrictions that differ between packaged (MSIX) and unpackaged apps for these APIs?

---

## Summary

Adds remarks to 12 files in `Microsoft.Windows.System.Power` (namespace overview, PowerManager class, 6 properties, 4 enums). Adds a C# code example to the PowerManager class showing battery status checks and event subscriptions.

## Changes

- **Namespace overview** (`microsoft_windows_system_power.md`): Usage guidance and common scenarios
- **PowerManager class** (`powermanager.md`): Static class guidance, packaged/unpackaged note, full C# example with battery check + event subscription + energy saver handling
- **6 property files**: BatteryStatus, EffectivePowerMode, EffectivePowerMode2, PowerSupplyStatus, RemainingDischargeTime, SystemSuspendStatus — usage guidance, related event/enum cross-references
- **4 enum files**: BatteryStatus, EffectivePowerMode, PowerSupplyStatus, SystemSuspendStatus — contextual remarks explaining when/how each value applies

## Motivation

OGF quality scan identified 22/32 files in this namespace with empty or minimal remarks. This PR fills the highest-impact gaps. All claims are derived from the API signatures, enum field descriptions, and existing remarks in sibling files — no unverifiable claims.