### PR TITLE
Clarify Window.Activate foreground behavior

### DIFF
--- a/microsoft.ui.xaml/window_activate_1797342875.md
+++ b/microsoft.ui.xaml/window_activate_1797342875.md
@@ -11,7 +11,7 @@ public void Activate()
 
 ## -description
 
-Attempts to activate the application window by bringing it to the foreground and setting the input focus to it.
+Attempts to activate the application window. The window must be attached to the calling thread's message queue. This method doesn't force a background app into the foreground. If the app is in the foreground when the system activates the window, the window is brought to the foreground (top of the Z-order) and receives input focus.
 
 ## -remarks
 

--- a/microsoft.ui.xaml/window_activate_1797342875.md
+++ b/microsoft.ui.xaml/window_activate_1797342875.md
@@ -11,7 +11,7 @@ public void Activate()
 
 ## -description
 
-Attempts to activate the application window. The window must be attached to the calling thread's message queue. This method doesn't force a background app into the foreground. If the app is in the foreground when the system activates the window, the window is brought to the foreground (top of the Z-order) and receives input focus.
+Attempts to activate the application window. If the calling app is in the foreground, the window is brought to the foreground (top of Z-order) and receives input focus. If the app is in the background, this method does not force the window into the foreground.
 
 ## -remarks
 


### PR DESCRIPTION
*This was largely generated by AI.  AI makes mistakes.*

## Summary
- Clarifies that `Window.Activate` attempts to activate the window, but doesn't force a background app into the foreground.
- Aligns the wording with the Win32 `SetActiveWindow` docs, including the calling thread message queue requirement and foreground app behavior.

## Source
- https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow