### PR TITLE
Update remarks for appwindowtitlebar_preferredheightoption

### DIFF
--- a/microsoft.ui.windowing/appwindowtitlebar_preferredheightoption.md
+++ b/microsoft.ui.windowing/appwindowtitlebar_preferredheightoption.md
@@ -21,6 +21,7 @@ A value of the enumeration that indicates the preferred height of the title bar.
 ## -remarks
 
 Check the [Height](appwindowtitlebar_height.md) property to get the new height value in client coordinates after setting this property.
+Setting this property while `AppWindowTitleBar.ExtendsContentIntoTitleBar` is `false` causes an exception to throw.
 
 ## -see-also
 

--- a/microsoft.ui.windowing/appwindowtitlebar_preferredheightoption.md
+++ b/microsoft.ui.windowing/appwindowtitlebar_preferredheightoption.md
@@ -21,7 +21,7 @@ A value of the enumeration that indicates the preferred height of the title bar.
 ## -remarks
 
 Check the [Height](appwindowtitlebar_height.md) property to get the new height value in client coordinates after setting this property.
-Setting this property while `AppWindowTitleBar.ExtendsContentIntoTitleBar` is `false` causes an exception to throw.
+Attempting to set this property while `AppWindowTitleBar.ExtendsContentIntoTitleBar` is `false` throws an exception.
 
 ## -see-also
 


### PR DESCRIPTION
Added note about exception when setting property with ExtendsContentIntoTitleBar as false.